### PR TITLE
Update news.css to preserve image scale

### DIFF
--- a/style/news.css
+++ b/style/news.css
@@ -34,6 +34,7 @@ td {
 img:not(.quiterss-img) {
   display: block;
   max-width: 100%;
+  height: auto;
 }
 
 div {


### PR DESCRIPTION
"height: auto;" was missing in img. Because of that, the proportion is nor kept when images are scaled down.
