### PR TITLE
Show notifier with 'Recent News', on tray single click

### DIFF
--- a/src/application/mainwindow.cpp
+++ b/src/application/mainwindow.cpp
@@ -55,7 +55,6 @@ MainWindow::MainWindow(QWidget *parent)
   , mediaPlayer_(NULL)
 #endif
   , updateAppDialog_(NULL)
-  , updateFeedsCount_(0)
   , notificationWidget(NULL)
   , feedIdOld_(-2)
   , isStartImportFeed_(false)
@@ -95,8 +94,8 @@ MainWindow::MainWindow(QWidget *parent)
 
   QTimer::singleShot(10000, this, SLOT(slotUpdateAppCheck()));
 
-  connect(this, SIGNAL(signalShowNotification()),
-          SLOT(showNotification()), Qt::QueuedConnection);
+  connect(this, SIGNAL(signalShowNotification(bool)),
+          SLOT(showNotification(bool)), Qt::QueuedConnection);
   connect(this, SIGNAL(signalPlaySoundNewNews()),
           SLOT(slotPlaySoundNewNews()), Qt::QueuedConnection);
 
@@ -112,6 +111,9 @@ MainWindow::MainWindow(QWidget *parent)
           this, SLOT(showDownloadManager(bool)));
   connect(mainApp->downloadManager(), SIGNAL(signalUpdateInfo(QString)),
           this, SLOT(updateInfoDownloads(QString)));
+
+  connect(&timerTrayOpenNotify, SIGNAL(timeout()), this, SLOT(slotTrayOpenNotifyTimer()));
+  timerTrayOpenNotify.setSingleShot(true);
 
   retranslateStrings();
 
@@ -304,7 +306,7 @@ void MainWindow::slotPlaceToTray()
     setFeedRead(currentNewsTab->type_, currentNewsTab->feedId_, FeedReadPlaceToTray, currentNewsTab);
   if (clearStatusNew_)
     QTimer::singleShot(0, this, SIGNAL(signalMarkAllFeedsOld()));
-  clearNotification();
+  clearNotification(true);
 
   saveSettings();
 
@@ -325,25 +327,63 @@ void MainWindow::slotActivationTray(QSystemTrayIcon::ActivationReason reason)
   case QSystemTrayIcon::Context:
     trayMenu_->activateWindow();
     break;
-  case QSystemTrayIcon::DoubleClick:
-    if (!singleClickTray_) {
-      if ((QDateTime::currentMSecsSinceEpoch() - activationStateChangedTime_ < 300) ||
-          isActiveWindow())
-        activated = true;
-      showWindows(activated);
-    }
-    break;
-  case QSystemTrayIcon::Trigger:
-    if (singleClickTray_) {
-      if (((QDateTime::currentMSecsSinceEpoch() - activationStateChangedTime_ < 200) && !isActiveWindow()) ||
-          (!(QDateTime::currentMSecsSinceEpoch() - activationStateChangedTime_ < 200) && isActiveWindow()))
-        activated = true;
-      showWindows(activated);
-    }
-    break;
+
+	case QSystemTrayIcon::DoubleClick:
+	{
+		if (!singleClickTray_)
+		{
+			timerTrayOpenNotify.stop();
+
+			if ((QDateTime::currentMSecsSinceEpoch() - activationStateChangedTime_ < 300) || isActiveWindow())
+			{
+				activated = true;
+			}
+
+			showWindows(activated);
+		}
+
+		break;
+	}
+
+	case QSystemTrayIcon::Trigger:
+	{
+		if (singleClickTray_)
+		{
+			qint64 LastActiveChangeTime = QDateTime::currentMSecsSinceEpoch() - activationStateChangedTime_;
+
+			if (isActiveWindow() ? (LastActiveChangeTime >= 200) : (LastActiveChangeTime < 200))
+			{
+				activated = true;
+			}
+
+			showWindows(activated);
+		}
+		else
+		{
+			if (notificationWidget == NULL)
+			{
+				if (!timerTrayOpenNotify.isActive())
+				{
+					timerTrayOpenNotify.start(400);
+				}
+			}
+			else
+			{
+				delete notificationWidget;
+				notificationWidget = NULL;
+			}
+		}
+		break;
+	}
+
   case QSystemTrayIcon::MiddleClick:
     break;
   }
+}
+
+void MainWindow::slotTrayOpenNotifyTimer()
+{
+	emit signalShowNotification(true);
 }
 
 /** @brief Show window on event
@@ -3030,32 +3070,54 @@ void MainWindow::slotUpdateFeed(int feedId, bool changed, int newCount, bool fin
   if (newCount > 0)
     emit signalPlaySoundNewNews();
 
-  // Manage notifications
-  bool showNotify = true;
-  if (showNotifyInactiveApp_)
-    showNotify = !isActiveWindow();
-  if (!showNotify) {
-    clearNotification();
-  } else if (newCount > 0) {
-    int feedIdIndex = idFeedList_.indexOf(feedId);
-    if (onlySelectedFeeds_) {
-      if(idFeedsNotifyList_.contains(feedId)) {
-        if (-1 < feedIdIndex) {
-          cntNewNewsList_[feedIdIndex] = newCount;
-        } else {
-          idFeedList_.append(feedId);
-          cntNewNewsList_.append(newCount);
-        }
-      }
-    } else {
-      if (-1 < feedIdIndex) {
-        cntNewNewsList_[feedIdIndex] = newCount;
-      } else {
-        idFeedList_.append(feedId);
-        cntNewNewsList_.append(newCount);
-      }
-    }
-  }
+	// Manage notifications
+	bool showNotify = true;
+
+	if (showNotifyInactiveApp_)
+	{
+		showNotify = !isActiveWindow();
+	}
+
+	if (!showNotify)
+	{
+		clearNotification();
+	}
+
+	if (newCount > 0)
+	{
+		bool bAddRecentNews = !onlySelectedFeeds_ || idFeedsNotifyList_.contains(feedId);
+		bool bAddNewNews = bAddRecentNews && showNotify;
+
+		if (bAddNewNews)
+		{
+			int NewFeedIdIndex = NewNews.idFeedList_.indexOf(feedId);
+
+			if (-1 < NewFeedIdIndex)
+			{
+				NewNews.cntNewsList_[NewFeedIdIndex] = newCount;
+			}
+			else
+			{
+				NewNews.idFeedList_.append(feedId);
+				NewNews.cntNewsList_.append(newCount);
+			}
+		}
+
+		if (bAddRecentNews)
+		{
+			int RecentFeedIdIndex = RecentNews.idFeedList_.indexOf(feedId);
+
+			if (-1 < RecentFeedIdIndex)
+			{
+				RecentNews.cntNewsList_[RecentFeedIdIndex] += newCount;
+			}
+			else
+			{
+				RecentNews.idFeedList_.append(feedId);
+				RecentNews.cntNewsList_.append(newCount);
+			}
+		}
+	}
 
   recountCategoryCounts();
 
@@ -6539,18 +6601,25 @@ void MainWindow::findText()
 
 /** @brief Show notification on inbox news
  *---------------------------------------------------------------------------*/
-void MainWindow::showNotification()
+void MainWindow::showNotification(bool bShowRecentNews/*=false*/)
 {
-  Settings settings;
-  settings.setValue("Flags/updatingFeeds", false);
+	Settings settings;
+	settings.setValue("Flags/updatingFeeds", false);
 
-  bool showNotify = true;
-  if (showNotifyInactiveApp_)
-    showNotify = !isActiveWindow();
-  if (idFeedList_.isEmpty() || !showNotify || !showNotifyOn_) {
-    clearNotification();
-    return;
-  }
+	bool showNotify = true;
+
+	if (showNotifyInactiveApp_)
+	{
+		showNotify = !isActiveWindow();
+	}
+
+	NewNewsData& CurNews = (bShowRecentNews ? RecentNews : NewNews);
+
+	if (CurNews.idFeedList_.isEmpty() || !showNotify || !showNotifyOn_)
+	{
+		clearNotification();
+		return;
+	}
 
   if (fullscreenModeNotify_) {
 #if defined(Q_OS_WIN)
@@ -6573,11 +6642,17 @@ void MainWindow::showNotification()
 #endif
   }
 
+  timerTrayOpenNotify.stop();
+
+
   if (notificationWidget) delete notificationWidget;
-  notificationWidget = new NotificationWidget(idFeedList_, cntNewNewsList_,
+  notificationWidget = new NotificationWidget(CurNews.idFeedList_, CurNews.cntNewsList_,
                                               idColorList_, colorList_, this);
 
-  clearNotification();
+	if (!bShowRecentNews)
+	{
+		clearNotification();
+	}
 
   connect(notificationWidget, SIGNAL(signalShow()), this, SLOT(showWindows()));
   connect(notificationWidget, SIGNAL(signalClose()),
@@ -6604,18 +6679,28 @@ void MainWindow::deleteNotification()
   notificationWidget = NULL;
 }
 
-void MainWindow::clearNotification()
+void MainWindow::clearNotification(bool bClearRecentNews/*=false*/)
 {
-  idFeedList_.clear();
-  cntNewNewsList_.clear();
-  idColorList_.clear();
-  colorList_.clear();
+	NewNews.idFeedList_.clear();
+	NewNews.cntNewsList_.clear();
+
+	if (bClearRecentNews)
+	{
+		RecentNews.idFeedList_.clear();
+		RecentNews.cntNewsList_.clear();
+
+		idColorList_.clear();
+		colorList_.clear();
+	}
 }
 
 void MainWindow::slotAddColorList(int id, const QString &color)
 {
-  idColorList_.append(id);
-  colorList_.append(color);
+	if (idColorList_.indexOf(id) == -1)
+	{
+		idColorList_.append(id);
+		colorList_.append(color);
+	}
 }
 
 /** @brief Show news on click in notification window

--- a/src/application/mainwindow.cpp
+++ b/src/application/mainwindow.cpp
@@ -2050,9 +2050,9 @@ void MainWindow::loadSettings()
 		MiddleClick = (int)ENewsClickAction::NCA_WebPageNewTab;
 	}
 
-	NewsSingleClickAction = (ENewsClickAction)SingleClick;
-	NewsDoubleClickAction = (ENewsClickAction)DoubleClick;
-	NewsMiddleClickAction = (ENewsClickAction)MiddleClick;
+	NewsSingleClickAction = (ENewsClickAction::Type)SingleClick;
+	NewsDoubleClickAction = (ENewsClickAction::Type)DoubleClick;
+	NewsMiddleClickAction = (ENewsClickAction::Type)MiddleClick;
 
   formatDate_ = settings.value("formatData", "dd.MM.yy").toString();
   formatTime_ = settings.value("formatTime", "hh:mm").toString();
@@ -3890,9 +3890,9 @@ void MainWindow::showOptionDlg(int index)
 
   showDescriptionNews_ = optionsDialog_->showDescriptionNews_->isChecked();
 
-  NewsSingleClickAction = (ENewsClickAction)optionsDialog_->SingleClickAction->currentData().toInt();
-  NewsDoubleClickAction = (ENewsClickAction)optionsDialog_->DoubleClickAction->currentData().toInt();
-  NewsMiddleClickAction = (ENewsClickAction)optionsDialog_->MiddleClickAction->currentData().toInt();
+  NewsSingleClickAction = (ENewsClickAction::Type)optionsDialog_->SingleClickAction->currentData().toInt();
+  NewsDoubleClickAction = (ENewsClickAction::Type)optionsDialog_->DoubleClickAction->currentData().toInt();
+  NewsMiddleClickAction = (ENewsClickAction::Type)optionsDialog_->MiddleClickAction->currentData().toInt();
 
   formatDate_ = optionsDialog_->formatDate_->itemData(
         optionsDialog_->formatDate_->currentIndex()).toString();
@@ -5299,9 +5299,9 @@ void MainWindow::showFeedPropertiesDlg()
   properties.general.displayOnStartup =
       feedsModel_->dataField(index, "displayOnStartup").toInt();
 
-	properties.Mouse.SingleClickAction = (ENewsClickAction)feedsModel_->dataField(index, "SingleClickAction").toInt();
-	properties.Mouse.DoubleClickAction = (ENewsClickAction)feedsModel_->dataField(index, "DoubleClickAction").toInt();
-	properties.Mouse.MiddleClickAction = (ENewsClickAction)feedsModel_->dataField(index, "MiddleClickAction").toInt();
+	properties.Mouse.SingleClickAction = (ENewsClickAction::Type)feedsModel_->dataField(index, "SingleClickAction").toInt();
+	properties.Mouse.DoubleClickAction = (ENewsClickAction::Type)feedsModel_->dataField(index, "DoubleClickAction").toInt();
+	properties.Mouse.MiddleClickAction = (ENewsClickAction::Type)feedsModel_->dataField(index, "MiddleClickAction").toInt();
 
   properties.display.displayEmbeddedImages =
       feedsModel_->dataField(index, "displayEmbeddedImages").toInt();

--- a/src/application/mainwindow.h
+++ b/src/application/mainwindow.h
@@ -290,6 +290,7 @@ public slots:
   void showOptionDlg(int index = -1);
   void slotPlaceToTray();
   void slotActivationTray(QSystemTrayIcon::ActivationReason reason);
+  void slotTrayOpenNotifyTimer();
   void showWindows(bool trayClick = false);
   void quitApp();
   void myEmptyWorkingSet();
@@ -319,7 +320,7 @@ signals:
   void faviconRequestUrl(QString urlString, QString feedUrl);
   void signalIconFeedReady(QString feedUrl, QByteArray faviconData);
   void signalSetCurrentTab(int index, bool updateTab = false);
-  void signalShowNotification();
+  void signalShowNotification(bool bShowRecentNews=false);
   void signalRefreshInfoTray();
   void signalNextUpdate(bool finish);
   void signalRecountCategoryCounts();
@@ -413,9 +414,9 @@ private slots:
   void setCurrentTab(int index, bool updateCurrentTab = false);
   void findText();
 
-  void showNotification();
+  void showNotification(bool bShowRecentNews=false);
   void deleteNotification();
-  void clearNotification();
+  void clearNotification(bool bClearRecentNews=false);
   void slotOpenNew(int feedId, int newsId);
   void slotOpenNewBrowser(const QUrl &url);
   void slotMarkReadNewsInNotification(int feedId, int newsId, int read);
@@ -725,11 +726,19 @@ private:
   bool cleanUpDeleted_;
   bool optimizeDB_;
 
-  int updateFeedsCount_;
-  QList<int> idFeedList_;
-  QList<int> cntNewNewsList_;
+  struct NewNewsData
+  {
+	  QList<int> idFeedList_;
+	  QList<int> cntNewsList_;
+  };
+
+  NewNewsData NewNews;
+  NewNewsData RecentNews;
+
   QList<int> idColorList_;
   QStringList colorList_;
+
+  QTimer timerTrayOpenNotify;
 
   bool reopenFeedStartup_;
   bool openNewTabNextToActive_;

--- a/src/application/mainwindow.h
+++ b/src/application/mainwindow.h
@@ -219,6 +219,9 @@ public:
   bool markReadClosingTab_;
   bool markReadMinimize_;
   bool showDescriptionNews_;
+  ENewsClickAction NewsSingleClickAction;
+  ENewsClickAction NewsDoubleClickAction;
+  ENewsClickAction NewsMiddleClickAction;
   bool alternatingRowColorsNews_;
   bool simplifiedDateTime_;
   bool notDeleteStarred_;
@@ -300,7 +303,7 @@ public slots:
   void slotUpdateStatus(int feedId, bool changed = true);
   void setNewsFilter(QAction*, bool clicked = true);
   void slotCloseTab(int index);
-  QWebPage *createWebTab(QUrl url = QUrl());
+  QWebPage *createWebTab(QUrl url = QUrl(), QString* OverrideHtml=NULL);
   void feedsModelReload(bool checkFilter = false);
   void setStatusFeed(int feedId, QString status);
   void slotPrint(QWebFrame *frame = 0);

--- a/src/application/mainwindow.h
+++ b/src/application/mainwindow.h
@@ -219,9 +219,9 @@ public:
   bool markReadClosingTab_;
   bool markReadMinimize_;
   bool showDescriptionNews_;
-  ENewsClickAction NewsSingleClickAction;
-  ENewsClickAction NewsDoubleClickAction;
-  ENewsClickAction NewsMiddleClickAction;
+  ENewsClickAction::Type NewsSingleClickAction;
+  ENewsClickAction::Type NewsDoubleClickAction;
+  ENewsClickAction::Type NewsMiddleClickAction;
   bool alternatingRowColorsNews_;
   bool simplifiedDateTime_;
   bool notDeleteStarred_;

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -26,7 +26,7 @@
 
 #include <sqlite3.h>
 
-const int versionDB = 16;
+const int versionDB = 17;
 
 const QString kCreateFeedsTableQuery(
     "CREATE TABLE feeds("
@@ -115,7 +115,11 @@ const QString kCreateFeedsTableQuery(
     "disableUpdate integer default 0, "     // disable update feed
     "javaScriptEnable integer default 1, "  //
     // version 16
-    "layoutDirection integer default 0 "    // 0 - ltr; 1 - rtl
+    "layoutDirection integer default 0, "    // 0 - ltr; 1 - rtl
+	// Version 17
+	"SingleClickAction integer default 0, "	// ENewsClickAction
+	"DoubleClickAction integer default 0, "	// ENewsClickAction
+	"MiddleClickAction integer default 0 "	// ENewsClickAction
     ")");
 
 const QString kCreateNewsTableQuery(
@@ -301,6 +305,13 @@ void Database::prepareDatabase()
         if (dbVersion < 16) {
           q.exec("ALTER TABLE feeds ADD COLUMN layoutDirection integer default 0");
         }
+
+		if (dbVersion < 17)
+		{
+			q.exec("ALTER table feeds ADD COLUMN SingleClickAction integer default 0");
+			q.exec("ALTER table feeds ADD COLUMN DoubleClickAction integer default 0");
+			q.exec("ALTER table feeds ADD COLUMN MiddleClickAction integer default 0");
+		}
 
         // Update appVersion anyway
         if (appVersion.isEmpty()) {

--- a/src/feedpropertiesdialog.cpp
+++ b/src/feedpropertiesdialog.cpp
@@ -546,9 +546,9 @@ FEED_PROPERTIES FeedPropertiesDialog::getFeedProperties()
   feedProperties.general.updateInterval = updateInterval_->value();
   feedProperties.general.intervalType = updateIntervalType_->currentIndex() - 1;
 
-	feedProperties.Mouse.SingleClickAction = (ENewsClickAction)SingleClickAction->currentData().toInt();
-	feedProperties.Mouse.DoubleClickAction = (ENewsClickAction)DoubleClickAction->currentData().toInt();
-	feedProperties.Mouse.MiddleClickAction = (ENewsClickAction)MiddleClickAction->currentData().toInt();
+	feedProperties.Mouse.SingleClickAction = (ENewsClickAction::Type)SingleClickAction->currentData().toInt();
+	feedProperties.Mouse.DoubleClickAction = (ENewsClickAction::Type)DoubleClickAction->currentData().toInt();
+	feedProperties.Mouse.MiddleClickAction = (ENewsClickAction::Type)MiddleClickAction->currentData().toInt();
 
   feedProperties.general.displayOnStartup = displayOnStartup->isChecked();
   feedProperties.general.starred = starredOn_->isChecked();

--- a/src/feedpropertiesdialog.cpp
+++ b/src/feedpropertiesdialog.cpp
@@ -29,6 +29,10 @@ FeedPropertiesDialog::FeedPropertiesDialog(bool isFeed, QWidget *parent)
 
   tabWidget = new QTabWidget();
   tabWidget->addTab(createGeneralTab(), tr("General"));
+
+  // @todo #JohnBTranslation
+  tabWidget->addTab(CreateMouseTab(), tr("Mouse"));
+
   tabWidget->addTab(createDisplayTab(), tr("Display"));
   tabWidget->addTab(createColumnsTab(), tr("Columns"));
   tabWidget->addTab(createAuthenticationTab(), tr("Authentication"));
@@ -165,27 +169,53 @@ QWidget *FeedPropertiesDialog::createGeneralTab()
   return tab;
 }
 //------------------------------------------------------------------------------
+QWidget *FeedPropertiesDialog::CreateMouseTab()
+{
+	QWidget* ReturnVal = new QWidget();
+	QVBoxLayout* TabLayout = new QVBoxLayout(ReturnVal);
+
+	{
+		TabLayout->setMargin(10);
+		TabLayout->setSpacing(5);
+
+		QWidget* ClickActionWidgets =
+			OptionsDialog::createClickActionWidgets(SingleClickAction, DoubleClickAction, MiddleClickAction, true);
+
+		TabLayout->addWidget(ClickActionWidgets);
+
+		TabLayout->addStretch();
+	}
+
+	return ReturnVal;
+}
+//------------------------------------------------------------------------------
 QWidget *FeedPropertiesDialog::createDisplayTab()
 {
-  QWidget *tab = new QWidget();
+	QWidget* ReturnVal = new QWidget();
+	QVBoxLayout* tabLayout = new QVBoxLayout(ReturnVal);
 
-  loadImagesOn_ = new QCheckBox(tr("Load images"));
-  loadImagesOn_->setTristate(true);
-  javaScriptEnable_ = new QCheckBox(tr("Enable JavaScript"));
-  javaScriptEnable_->setTristate(true);
-  showDescriptionNews_ = new QCheckBox(tr("Show news' description instead of loading web page"));
-  layoutDirection_ = new QCheckBox(tr("Right-to-left layout"));
+	{
+		tabLayout->setMargin(10);
+		tabLayout->setSpacing(5);
 
-  QVBoxLayout *tabLayout = new QVBoxLayout(tab);
-  tabLayout->setMargin(10);
-  tabLayout->setSpacing(5);
-  tabLayout->addWidget(loadImagesOn_);
-  tabLayout->addWidget(javaScriptEnable_);
-  tabLayout->addWidget(showDescriptionNews_);
-  tabLayout->addWidget(layoutDirection_);
-  tabLayout->addStretch();
+		loadImagesOn_ = new QCheckBox(tr("Load images"));
+		loadImagesOn_->setTristate(true);
+		javaScriptEnable_ = new QCheckBox(tr("Enable JavaScript"));
+		javaScriptEnable_->setTristate(true);
 
-  return tab;
+		showDescriptionNews_ = new QCheckBox(tr("Show news' description instead of loading web page"));
+
+		layoutDirection_ = new QCheckBox(tr("Right-to-left layout"));
+
+		tabLayout->addWidget(loadImagesOn_);
+		tabLayout->addWidget(javaScriptEnable_);
+		tabLayout->addWidget(showDescriptionNews_);
+		tabLayout->addWidget(layoutDirection_);
+
+		tabLayout->addStretch();
+	}
+
+	return ReturnVal;
 }
 //------------------------------------------------------------------------------
 QWidget *FeedPropertiesDialog::createColumnsTab()
@@ -373,6 +403,15 @@ QWidget *FeedPropertiesDialog::createStatusTab()
   starredOn_->setChecked(feedProperties.general.starred);
   duplicateNewsMode_->setChecked(feedProperties.general.duplicateNewsMode);
 
+	int CurClickValIdx = SingleClickAction->findData((int)feedProperties.Mouse.SingleClickAction);
+	SingleClickAction->setCurrentIndex(CurClickValIdx);
+
+	CurClickValIdx = SingleClickAction->findData((int)feedProperties.Mouse.DoubleClickAction);
+	DoubleClickAction->setCurrentIndex(CurClickValIdx);
+
+	CurClickValIdx = SingleClickAction->findData((int)feedProperties.Mouse.MiddleClickAction);
+	MiddleClickAction->setCurrentIndex(CurClickValIdx);
+
   loadImagesOn_->setCheckState((Qt::CheckState)feedProperties.display.displayEmbeddedImages);
   javaScriptEnable_->setCheckState((Qt::CheckState)feedProperties.display.javaScriptEnable);
   showDescriptionNews_->setChecked(!feedProperties.display.displayNews);
@@ -506,6 +545,10 @@ FEED_PROPERTIES FeedPropertiesDialog::getFeedProperties()
   feedProperties.general.updateEnable = updateEnable_->isChecked();
   feedProperties.general.updateInterval = updateInterval_->value();
   feedProperties.general.intervalType = updateIntervalType_->currentIndex() - 1;
+
+	feedProperties.Mouse.SingleClickAction = (ENewsClickAction)SingleClickAction->currentData().toInt();
+	feedProperties.Mouse.DoubleClickAction = (ENewsClickAction)DoubleClickAction->currentData().toInt();
+	feedProperties.Mouse.MiddleClickAction = (ENewsClickAction)MiddleClickAction->currentData().toInt();
 
   feedProperties.general.displayOnStartup = displayOnStartup->isChecked();
   feedProperties.general.starred = starredOn_->isChecked();

--- a/src/feedpropertiesdialog.h
+++ b/src/feedpropertiesdialog.h
@@ -21,6 +21,7 @@
 #include "dialog.h"
 #include "lineedit.h"
 #include "toolbutton.h"
+#include "optionsdialog.h"
 
 //! Feed properties structure
 typedef struct {
@@ -112,6 +113,14 @@ typedef struct {
     int feedsCount; //!< Number of feeds
   } status;
 
+	//! Mouse properties
+	struct Mouse
+	{
+		ENewsClickAction SingleClickAction;	//!< Action to take on single click
+		ENewsClickAction DoubleClickAction;	//!< Action to take on double click
+		ENewsClickAction MiddleClickAction;	//!< Action to take on middle click
+	} Mouse;
+
 } FEED_PROPERTIES;
 
 //! Feed properties dialog
@@ -162,6 +171,13 @@ private:
   QCheckBox *duplicateNewsMode_;
 
   QWidget *createGeneralTab();
+
+  // Tab "Mouse"
+  	QComboBox* SingleClickAction;
+	QComboBox* DoubleClickAction;
+	QComboBox* MiddleClickAction;
+
+	QWidget* CreateMouseTab();
 
   // Tab "Display"
   QCheckBox *showDescriptionNews_;

--- a/src/feedpropertiesdialog.h
+++ b/src/feedpropertiesdialog.h
@@ -116,9 +116,9 @@ typedef struct {
 	//! Mouse properties
 	struct Mouse
 	{
-		ENewsClickAction SingleClickAction;	//!< Action to take on single click
-		ENewsClickAction DoubleClickAction;	//!< Action to take on double click
-		ENewsClickAction MiddleClickAction;	//!< Action to take on middle click
+		ENewsClickAction::Type SingleClickAction;	//!< Action to take on single click
+		ENewsClickAction::Type DoubleClickAction;	//!< Action to take on double click
+		ENewsClickAction::Type MiddleClickAction;	//!< Action to take on middle click
 	} Mouse;
 
 } FEED_PROPERTIES;

--- a/src/newstabwidget.cpp
+++ b/src/newstabwidget.cpp
@@ -2971,9 +2971,9 @@ void NewsTabWidget::actionNewspaper(QUrl url)
 void NewsTabWidget::HandleMouseClick(QModelIndex index, Qt::MouseButton Button, bool bDoubleClick/*=false*/)
 {
 	QModelIndex feedIndex = feedsModel_->indexById(feedId_);
-	ENewsClickAction SingleClickAction = (ENewsClickAction)feedsModel_->dataField(feedIndex, "SingleClickAction").toInt();
-	ENewsClickAction DoubleClickAction = (ENewsClickAction)feedsModel_->dataField(feedIndex, "DoubleClickAction").toInt();
-	ENewsClickAction MiddleClickAction = (ENewsClickAction)feedsModel_->dataField(feedIndex, "MiddleClickAction").toInt();
+	ENewsClickAction::Type SingleClickAction = (ENewsClickAction::Type)feedsModel_->dataField(feedIndex, "SingleClickAction").toInt();
+	ENewsClickAction::Type DoubleClickAction = (ENewsClickAction::Type)feedsModel_->dataField(feedIndex, "DoubleClickAction").toInt();
+	ENewsClickAction::Type MiddleClickAction = (ENewsClickAction::Type)feedsModel_->dataField(feedIndex, "MiddleClickAction").toInt();
 
 	SingleClickAction = (SingleClickAction == ENewsClickAction::NCA_Default ? mainWindow_->NewsSingleClickAction : SingleClickAction);
 	DoubleClickAction = (DoubleClickAction == ENewsClickAction::NCA_Default ? mainWindow_->NewsDoubleClickAction : DoubleClickAction);
@@ -3044,15 +3044,17 @@ void NewsTabWidget::slotMouseClickTimeout()
 	if (PendingClickIndex.isValid())
 	{
 		QModelIndex feedIndex = feedsModel_->indexById(feedId_);
-		ENewsClickAction SingleClickAction = (ENewsClickAction)feedsModel_->dataField(feedIndex, "SingleClickAction").toInt();
+		ENewsClickAction::Type SingleClickAction =
+			(ENewsClickAction::Type)feedsModel_->dataField(feedIndex, "SingleClickAction").toInt();
 
-		SingleClickAction = (SingleClickAction == ENewsClickAction::NCA_Default ? mainWindow_->NewsSingleClickAction : SingleClickAction);
+		SingleClickAction = (SingleClickAction == ENewsClickAction::NCA_Default ? mainWindow_->NewsSingleClickAction :
+								SingleClickAction);
 
 		PerformNewsClickAction(PendingClickIndex, SingleClickAction);
 	}
 }
 
-void NewsTabWidget::PerformNewsClickAction(QModelIndex index, ENewsClickAction Action)
+void NewsTabWidget::PerformNewsClickAction(QModelIndex index, ENewsClickAction::Type Action)
 {
 	if (index.isValid())
 	{

--- a/src/newstabwidget.h
+++ b/src/newstabwidget.h
@@ -36,6 +36,7 @@
 #include "newsmodel.h"
 #include "newsview.h"
 #include "webview.h"
+#include "optionsdialog.h"
 
 class MainWindow;
 
@@ -92,6 +93,9 @@ public:
   void openNewsNewTab();
 
   void updateWebView(QModelIndex index);
+  void updateWebView_Link(QModelIndex index, bool bExternalLink=false, QString OverrideURL="");
+  void updateWebView_Description(QModelIndex index);
+  void GenerateDescriptionHtml(QModelIndex index, QString& OutHtml, QUrl& OutURL);
   void loadNewspaper(int refresh = RefreshAll);
   void hideWebContent();
   QString getLinkNews(int row);
@@ -143,7 +147,7 @@ public:
 public slots:
   void setAutoLoadImages(bool apply = true);
   void slotNewsViewClicked(QModelIndex index);
-  void slotNewsViewSelected(QModelIndex index, bool clicked = false);
+  void slotNewsViewSelected(QModelIndex index, bool clicked=false, bool bUpdateWebView=true);
   void slotNewsViewDoubleClicked(QModelIndex index);
   void slotNewsMiddleClicked(QModelIndex index);
   void slotNewsUpPressed(QModelIndex index=QModelIndex());
@@ -168,7 +172,7 @@ private slots:
   void setHtmlWebView(const QString &html, const QUrl &baseUrl);
   void webHomePage();
   void openPageInExternalBrowser();
-  void slotLinkClicked(QUrl url);
+  void slotLinkClicked(QUrl url, bool bForceNewTab=false, bool bForceNewBkgTab=false, QString* OverrideHtml=NULL);
   void slotLinkHovered(const QString &link, const QString &str1="", const QString &str2="");
   void slotSetValue(int value);
   void slotLoadStarted();
@@ -190,11 +194,17 @@ private slots:
 
   void slotNewslLabelClicked(QModelIndex index);
 
+  void slotMouseClickTimeout();
+
 private:
   void createNewsList();
   void createWebWidget();
   QString getHtmlLabels(int row);
   void actionNewspaper(QUrl url);
+
+  void HandleMouseClick(QModelIndex index, Qt::MouseButton Button, bool bDoubleClick=false);
+
+  void PerformNewsClickAction(QModelIndex index, ENewsClickAction Action);
 
   MainWindow *mainWindow_;
   QSqlDatabase db_;
@@ -233,6 +243,8 @@ private:
   QString audioPlayerHtml_;
   QString videoPlayerHtml_;
 
+  QTimer TimerMouseClick;
+  QPersistentModelIndex PendingClickIndex;
 };
 
 #endif // NEWSTABWIDGET_H

--- a/src/newstabwidget.h
+++ b/src/newstabwidget.h
@@ -204,7 +204,7 @@ private:
 
   void HandleMouseClick(QModelIndex index, Qt::MouseButton Button, bool bDoubleClick=false);
 
-  void PerformNewsClickAction(QModelIndex index, ENewsClickAction Action);
+  void PerformNewsClickAction(QModelIndex index, ENewsClickAction::Type Action);
 
   MainWindow *mainWindow_;
   QSqlDatabase db_;

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -886,63 +886,92 @@ void OptionsDialog::createFeedsWidget()
   QWidget *generalFeedsWidget = new QWidget();
   generalFeedsWidget->setLayout(generalFeedsLayout);
 
-//! tab "Reading"
-  markNewsReadOn_ = new QGroupBox(tr("Mark news as read:"));
-  markNewsReadOn_->setCheckable(true);
-  markCurNewsRead_ = new QRadioButton(tr("on selecting. With timeout"));
-  markPrevNewsRead_ = new QRadioButton(tr("after switching to another news"));
-  markNewsReadTime_ = new QSpinBox();
-  markNewsReadTime_->setEnabled(false);
-  markNewsReadTime_->setRange(0, 100);
-  connect(markCurNewsRead_, SIGNAL(toggled(bool)),
-          markNewsReadTime_, SLOT(setEnabled(bool)));
-  markReadSwitchingFeed_ = new QCheckBox(tr("Mark displayed news as read when switching feeds"));
-  markReadClosingTab_ = new QCheckBox(tr("Mark displayed news as read when closing tab"));
-  markReadMinimize_ = new QCheckBox(tr("Mark displayed news as read on minimize"));
 
-  showDescriptionNews_ = new QCheckBox(
-        tr("Show news description instead of loading web page"));
+	//! tab "Reading"
+	QVBoxLayout* ReadingMainLayout = new QVBoxLayout();
 
-  changeBehaviorActionNUN_ = new QCheckBox(tr("Change behavior of action 'Next Unread News'"));
+	{
+		markNewsReadOn_ = new QGroupBox(tr("Mark news as read:"));
 
-  notDeleteStarred_ = new QCheckBox(tr("starred news"));
-  notDeleteLabeled_ = new QCheckBox(tr("labeled news"));
+		markNewsReadOn_->setCheckable(true);
 
-  markIdenticalNewsRead_ = new QCheckBox(tr("Automatically mark identical news as read"));
+		{
+			QVBoxLayout* RadioLayout = new QVBoxLayout();
 
-  QHBoxLayout *readingFeedsLayout1 = new QHBoxLayout();
-  readingFeedsLayout1->setMargin(0);
-  readingFeedsLayout1->addWidget(markCurNewsRead_);
-  readingFeedsLayout1->addWidget(markNewsReadTime_);
-  readingFeedsLayout1->addWidget(new QLabel(tr("seconds")));
-  readingFeedsLayout1->addStretch();
+			{
+				QHBoxLayout* CurLayout = new QHBoxLayout();
 
-  QVBoxLayout *readingFeedsLayout2 = new QVBoxLayout();
-  readingFeedsLayout2->addLayout(readingFeedsLayout1);
-  readingFeedsLayout2->addWidget(markPrevNewsRead_);
-  markNewsReadOn_->setLayout(readingFeedsLayout2);
+				markCurNewsRead_ = new QRadioButton(tr("on selecting. With timeout"));
 
-  QGridLayout *readingFeedsLayout3 = new QGridLayout();
-  readingFeedsLayout3->setContentsMargins(15, 0, 0, 10);
-  readingFeedsLayout3->addWidget(notDeleteStarred_, 0, 0, 1, 1);
-  readingFeedsLayout3->addWidget(notDeleteLabeled_, 1, 0, 1, 1);
+				markNewsReadTime_ = new QSpinBox();
+				markNewsReadTime_->setEnabled(false);
+				markNewsReadTime_->setRange(0, 100);
+				connect(markCurNewsRead_, SIGNAL(toggled(bool)),
+					markNewsReadTime_, SLOT(setEnabled(bool)));
 
-  QVBoxLayout *readingFeedsLayout = new QVBoxLayout();
-  readingFeedsLayout->addWidget(markNewsReadOn_);
-  readingFeedsLayout->addWidget(markReadSwitchingFeed_);
-  readingFeedsLayout->addWidget(markReadClosingTab_);
-  readingFeedsLayout->addWidget(markReadMinimize_);
-  readingFeedsLayout->addSpacing(10);
-  readingFeedsLayout->addWidget(showDescriptionNews_);
-  readingFeedsLayout->addSpacing(10);
-  readingFeedsLayout->addWidget(new QLabel(tr("Prevent accidental deletion of:")));
-  readingFeedsLayout->addLayout(readingFeedsLayout3);
-  readingFeedsLayout->addWidget(changeBehaviorActionNUN_);
-  readingFeedsLayout->addWidget(markIdenticalNewsRead_);
-  readingFeedsLayout->addStretch();
+				CurLayout->setMargin(0);
+				CurLayout->addWidget(markCurNewsRead_);
+				CurLayout->addWidget(markNewsReadTime_);
+				CurLayout->addWidget(new QLabel(tr("seconds")));
+				CurLayout->addStretch();
 
-  QWidget *readingFeedsWidget = new QWidget();
-  readingFeedsWidget->setLayout(readingFeedsLayout);
+				RadioLayout->addLayout(CurLayout);
+			}
+
+			markPrevNewsRead_ = new QRadioButton(tr("after switching to another news"));
+
+			RadioLayout->addWidget(markPrevNewsRead_);
+			markNewsReadOn_->setLayout(RadioLayout);
+		}
+
+		ReadingMainLayout->addWidget(markNewsReadOn_);
+
+
+		markReadSwitchingFeed_ = new QCheckBox(tr("Mark displayed news as read when switching feeds"));
+		markReadClosingTab_ = new QCheckBox(tr("Mark displayed news as read when closing tab"));
+		markReadMinimize_ = new QCheckBox(tr("Mark displayed news as read on minimize"));
+
+		showDescriptionNews_ = new QCheckBox(tr("Show news description instead of loading web page"));
+
+		ReadingMainLayout->addWidget(markReadSwitchingFeed_);
+		ReadingMainLayout->addWidget(markReadClosingTab_);
+		ReadingMainLayout->addWidget(markReadMinimize_);
+		ReadingMainLayout->addSpacing(10);
+		ReadingMainLayout->addWidget(showDescriptionNews_);
+
+		QWidget* ClickActionWidgets = createClickActionWidgets(SingleClickAction, DoubleClickAction, MiddleClickAction);
+
+		ReadingMainLayout->addWidget(ClickActionWidgets);
+		ReadingMainLayout->addSpacing(10);
+		ReadingMainLayout->addWidget(new QLabel(tr("Prevent accidental deletion of:")));
+
+
+		{
+			QGridLayout* CurLayout = new QGridLayout();
+
+			notDeleteStarred_ = new QCheckBox(tr("starred news"));
+			notDeleteLabeled_ = new QCheckBox(tr("labeled news"));
+
+			CurLayout->setContentsMargins(15, 0, 0, 10);
+			CurLayout->addWidget(notDeleteStarred_, 0, 0, 1, 1);
+			CurLayout->addWidget(notDeleteLabeled_, 1, 0, 1, 1);
+
+			ReadingMainLayout->addLayout(CurLayout);
+		}
+
+		changeBehaviorActionNUN_ = new QCheckBox(tr("Change behavior of action 'Next Unread News'"));
+		markIdenticalNewsRead_ = new QCheckBox(tr("Automatically mark identical news as read"));
+
+		ReadingMainLayout->addWidget(changeBehaviorActionNUN_);
+		ReadingMainLayout->addWidget(markIdenticalNewsRead_);
+	}
+
+	ReadingMainLayout->addStretch();
+
+	QWidget* readingFeedsWidget = new QWidget();
+
+	readingFeedsWidget->setLayout(ReadingMainLayout);
+
 
 //! tab "Clean Up"
   QWidget *cleanUpFeedsWidget = new QWidget();
@@ -1000,6 +1029,89 @@ void OptionsDialog::createFeedsWidget()
   feedsWidget_->addTab(generalFeedsWidget, tr("General"));
   feedsWidget_->addTab(readingFeedsWidget, tr("Reading"));
   feedsWidget_->addTab(cleanUpFeedsWidget, tr("Clean Up"));
+}
+
+QWidget* OptionsDialog::createClickActionWidgets(QComboBox*& OutSingleClickAction, QComboBox*& OutDoubleClickAction,
+													QComboBox*& OutMiddleClickAction, bool bAddDefaultValue/*=false*/)
+{
+	// @todo #JohnBTranslation
+	QGroupBox* ReturnVal = new QGroupBox(tr("Action on news opening:"));
+
+	{
+		QHBoxLayout* ActionLayoutLeft = new QHBoxLayout();
+		QHBoxLayout* ActionLayoutRight = new QHBoxLayout();
+
+		{
+			QVBoxLayout* NamesLayout = new QVBoxLayout();
+			QVBoxLayout* ValuesLayout = new QVBoxLayout();
+
+			{
+				auto SetupCombo =
+					[&](QComboBox*& OutCombo)
+					{
+						OutCombo = new QComboBox();
+
+						if (bAddDefaultValue)
+						{
+							// @todo #JohnBTranslation
+							OutCombo->addItem("Default", (int)ENewsClickAction::NCA_Default);
+							OutCombo->insertSeparator(OutCombo->count());
+						}
+
+						// @todo #JohnBTranslation
+						OutCombo->addItem("Nothing", (int)ENewsClickAction::NCA_Nothing);
+						OutCombo->insertSeparator(OutCombo->count());
+
+						// @todo #JohnBTranslation
+						OutCombo->addItem("Show News Description", (int)ENewsClickAction::NCA_Description);
+						// @todo #JohnBTranslation
+						OutCombo->addItem("Show News Description in New Tab", (int)ENewsClickAction::NCA_DescriptionNewTab);
+						// @todo #JohnBTranslation
+						OutCombo->addItem("Show News Description in New Tab (Background)",
+											(int)ENewsClickAction::NCA_DescriptionBkgTab);
+						OutCombo->insertSeparator(OutCombo->count());
+
+						// @todo #JohnBTranslation
+						OutCombo->addItem("Load Web Page", (int)ENewsClickAction::NCA_WebPage);
+						// @todo #JohnBTranslation
+						OutCombo->addItem("Load Web Page in New Tab", (int)ENewsClickAction::NCA_WebPageNewTab);
+						// @todo #JohnBTranslation
+						OutCombo->addItem("Load Web Page in New Tab (Background)", (int)ENewsClickAction::NCA_WebPageBkgTab);
+						OutCombo->insertSeparator(OutCombo->count());
+
+						// @todo #JohnBTranslation
+						OutCombo->addItem("Open in External Browser", (int)ENewsClickAction::NCA_ExternalBrowser);
+					};
+
+				SetupCombo(OutSingleClickAction);
+				SetupCombo(OutDoubleClickAction);
+				SetupCombo(OutMiddleClickAction);
+
+				// @todo #JohnBTranslation
+				NamesLayout->addWidget(new QLabel(tr("Single Click:")));
+				ValuesLayout->addWidget(OutSingleClickAction);
+
+				// @todo #JohnBTranslation
+				NamesLayout->addWidget(new QLabel(tr("Double Click:")));
+				ValuesLayout->addWidget(OutDoubleClickAction);
+
+				// @todo #JohnBTranslation
+				NamesLayout->addWidget(new QLabel(tr("Middle Click:")));
+				ValuesLayout->addWidget(OutMiddleClickAction);
+			}
+
+
+			ActionLayoutLeft->addLayout(NamesLayout);
+			ActionLayoutRight->addLayout(ValuesLayout);
+		}
+
+		ActionLayoutRight->addStretch();
+		ActionLayoutLeft->addLayout(ActionLayoutRight);
+
+		ReturnVal->setLayout(ActionLayoutLeft);
+	}
+
+	return ReturnVal;
 }
 
 /** @brief Create widget "Labels"

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -1046,8 +1046,9 @@ QWidget* OptionsDialog::createClickActionWidgets(QComboBox*& OutSingleClickActio
 			QVBoxLayout* ValuesLayout = new QVBoxLayout();
 
 			{
-				auto SetupCombo =
-					[&](QComboBox*& OutCombo)
+				struct Local
+				{
+					static void SetupCombo(QComboBox*& OutCombo, bool bAddDefaultValue)
 					{
 						OutCombo = new QComboBox();
 
@@ -1082,10 +1083,11 @@ QWidget* OptionsDialog::createClickActionWidgets(QComboBox*& OutSingleClickActio
 						// @todo #JohnBTranslation
 						OutCombo->addItem("Open in External Browser", (int)ENewsClickAction::NCA_ExternalBrowser);
 					};
+				};
 
-				SetupCombo(OutSingleClickAction);
-				SetupCombo(OutDoubleClickAction);
-				SetupCombo(OutMiddleClickAction);
+				Local::SetupCombo(OutSingleClickAction, bAddDefaultValue);
+				Local::SetupCombo(OutDoubleClickAction, bAddDefaultValue);
+				Local::SetupCombo(OutMiddleClickAction, bAddDefaultValue);
 
 				// @todo #JohnBTranslation
 				NamesLayout->addWidget(new QLabel(tr("Single Click:")));

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -44,22 +44,25 @@ class FeedPropertiesDialog;
  * Action to take upon clicking a news entry
  * NOTE: Don't change value of 'Default' away from 0
  */
-enum ENewsClickAction
+namespace ENewsClickAction
 {
-	NCA_Start				= 0,
+	enum Type
+	{
+		NCA_Start				= 0,
 
-	NCA_Default				= 0,
-	NCA_Nothing				= 1,
-	NCA_Description			= 2,
-	NCA_DescriptionNewTab	= 3,
-	NCA_DescriptionBkgTab	= 4,
-	NCA_WebPage				= 5,
-	NCA_WebPageNewTab		= 6,
-	NCA_WebPageBkgTab		= 7,
-	NCA_ExternalBrowser		= 8,
+		NCA_Default				= 0,
+		NCA_Nothing				= 1,
+		NCA_Description			= 2,
+		NCA_DescriptionNewTab	= 3,
+		NCA_DescriptionBkgTab	= 4,
+		NCA_WebPage				= 5,
+		NCA_WebPageNewTab		= 6,
+		NCA_WebPageBkgTab		= 7,
+		NCA_ExternalBrowser		= 8,
 
-	NCA_Max
-};
+		NCA_Max
+	};
+}
 
 class OptionsDialog : public Dialog
 {

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -44,7 +44,7 @@ class FeedPropertiesDialog;
  * Action to take upon clicking a news entry
  * NOTE: Don't change value of 'Default' away from 0
  */
-enum class ENewsClickAction
+enum ENewsClickAction
 {
 	NCA_Start				= 0,
 

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -30,13 +30,41 @@
 #include "lineedit.h"
 #include "notificationswidget.h"
 
+
+// Forward declarations
+class FeedPropertiesDialog;
+
+
 #define STATIC_ICON_TRAY        0
 #define CHANGE_ICON_TRAY        1
 #define NEW_COUNT_ICON_TRAY     2
 #define UNREAD_COUNT_ICON_TRAY  3
 
+/**
+ * Action to take upon clicking a news entry
+ * NOTE: Don't change value of 'Default' away from 0
+ */
+enum class ENewsClickAction
+{
+	NCA_Start				= 0,
+
+	NCA_Default				= 0,
+	NCA_Nothing				= 1,
+	NCA_Description			= 2,
+	NCA_DescriptionNewTab	= 3,
+	NCA_DescriptionBkgTab	= 4,
+	NCA_WebPage				= 5,
+	NCA_WebPageNewTab		= 6,
+	NCA_WebPageBkgTab		= 7,
+	NCA_ExternalBrowser		= 8,
+
+	NCA_Max
+};
+
 class OptionsDialog : public Dialog
 {
+	friend FeedPropertiesDialog;
+
   Q_OBJECT
 public:
   explicit OptionsDialog(QWidget *parent);
@@ -128,6 +156,10 @@ public:
   QCheckBox *markReadMinimize_;
 
   QCheckBox *showDescriptionNews_;
+
+	QComboBox* SingleClickAction;
+	QComboBox* DoubleClickAction;
+	QComboBox* MiddleClickAction;
 
   QComboBox *formatDate_;
   QComboBox *formatTime_;
@@ -315,6 +347,18 @@ private:
 
   // feeds
   void createFeedsWidget();
+
+	/**
+	 * Creates the widgets for configuring news mouse click settings; shared between options dialog and feed properties dialog.
+	 *
+	 * @param OutSingleClickAction	Variable storing the single click widget
+	 * @param OutDoubleClickAction	Variable storing the double click widget
+	 * @param OutMiddleClickAction	Variable storing the middle click widget
+	 * @param bAddDefaultValue		Adds a value marked 'Default' to the combo box (for feed properties)
+	 * @return						Returns the widget for configuring the mouse settings
+	 */
+	static QWidget* createClickActionWidgets(QComboBox*& OutSingleClickAction, QComboBox*& OutDoubleClickAction,
+												QComboBox*& OutMiddleClickAction, bool bAddDefaultValue=false);
 
   // notifier
   void createNotifierWidget();

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -63,7 +63,7 @@ enum class ENewsClickAction
 
 class OptionsDialog : public Dialog
 {
-	friend FeedPropertiesDialog;
+	friend class FeedPropertiesDialog;
 
   Q_OBJECT
 public:


### PR DESCRIPTION
- 'Recent News' covers all news received since last minimized to tray
- No config options, this feature is disabled if 'single-click-open tray' config is checked
- Avoids open on double-click, by waiting 400ms; make configurable in future

Relates to issue #810
