### PR TITLE
Added ability to configure news mouse buttons

### DIFF
--- a/src/application/mainwindow.h
+++ b/src/application/mainwindow.h
@@ -219,6 +219,9 @@ public:
   bool markReadClosingTab_;
   bool markReadMinimize_;
   bool showDescriptionNews_;
+  ENewsClickAction::Type newsSingleClickAction;
+  ENewsClickAction::Type newsDoubleClickAction;
+  ENewsClickAction::Type newsMiddleClickAction;
   bool alternatingRowColorsNews_;
   bool simplifiedDateTime_;
   bool notDeleteStarred_;
@@ -299,7 +302,7 @@ public slots:
   void slotUpdateStatus(int feedId, bool changed = true);
   void setNewsFilter(QAction*, bool clicked = true);
   void slotCloseTab(int index);
-  QWebPage *createWebTab(QUrl url = QUrl());
+  QWebPage *createWebTab(QUrl url = QUrl(), QString* overrideHtml=NULL);
   void feedsModelReload(bool checkFilter = false);
   void setStatusFeed(int feedId, QString status);
   void slotPrint(QWebFrame *frame = 0);

--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -26,7 +26,7 @@
 
 #include <sqlite3.h>
 
-const int versionDB = 16;
+const int versionDB = 17;
 
 const QString kCreateFeedsTableQuery(
     "CREATE TABLE feeds("
@@ -115,7 +115,11 @@ const QString kCreateFeedsTableQuery(
     "disableUpdate integer default 0, "     // disable update feed
     "javaScriptEnable integer default 1, "  //
     // version 16
-    "layoutDirection integer default 0 "    // 0 - ltr; 1 - rtl
+    "layoutDirection integer default 0, "    // 0 - ltr; 1 - rtl
+    // Version 17
+    "SingleClickAction integer default 0, " // ENewsClickAction
+    "DoubleClickAction integer default 0, " // ENewsClickAction
+    "MiddleClickAction integer default 0 "  // ENewsClickAction
     ")");
 
 const QString kCreateNewsTableQuery(
@@ -300,6 +304,13 @@ void Database::prepareDatabase()
         }
         if (dbVersion < 16) {
           q.exec("ALTER TABLE feeds ADD COLUMN layoutDirection integer default 0");
+        }
+
+        if (dbVersion < 17)
+        {
+          q.exec("ALTER table feeds ADD COLUMN SingleClickAction integer default 0");
+          q.exec("ALTER table feeds ADD COLUMN DoubleClickAction integer default 0");
+          q.exec("ALTER table feeds ADD COLUMN MiddleClickAction integer default 0");
         }
 
         // Update appVersion anyway

--- a/src/feedpropertiesdialog.cpp
+++ b/src/feedpropertiesdialog.cpp
@@ -29,6 +29,10 @@ FeedPropertiesDialog::FeedPropertiesDialog(bool isFeed, QWidget *parent)
 
   tabWidget = new QTabWidget();
   tabWidget->addTab(createGeneralTab(), tr("General"));
+
+  // @todo #JohnBTranslation
+  tabWidget->addTab(createMouseTab(), tr("Mouse"));
+
   tabWidget->addTab(createDisplayTab(), tr("Display"));
   tabWidget->addTab(createColumnsTab(), tr("Columns"));
   tabWidget->addTab(createAuthenticationTab(), tr("Authentication"));
@@ -165,27 +169,53 @@ QWidget *FeedPropertiesDialog::createGeneralTab()
   return tab;
 }
 //------------------------------------------------------------------------------
+QWidget* FeedPropertiesDialog::createMouseTab()
+{
+  QWidget* returnVal = new QWidget();
+  QVBoxLayout* tabLayout = new QVBoxLayout(returnVal);
+
+  {
+    tabLayout->setMargin(10);
+    tabLayout->setSpacing(5);
+
+    QWidget* clickActionWidgets =
+      OptionsDialog::createClickActionWidgets(singleClickAction, doubleClickAction, middleClickAction, true);
+
+    tabLayout->addWidget(clickActionWidgets);
+
+    tabLayout->addStretch();
+  }
+
+  return returnVal;
+}
+//------------------------------------------------------------------------------
 QWidget *FeedPropertiesDialog::createDisplayTab()
 {
-  QWidget *tab = new QWidget();
+  QWidget* returnVal = new QWidget();
+  QVBoxLayout* tabLayout = new QVBoxLayout(returnVal);
 
-  loadImagesOn_ = new QCheckBox(tr("Load images"));
-  loadImagesOn_->setTristate(true);
-  javaScriptEnable_ = new QCheckBox(tr("Enable JavaScript"));
-  javaScriptEnable_->setTristate(true);
-  showDescriptionNews_ = new QCheckBox(tr("Show news' description instead of loading web page"));
-  layoutDirection_ = new QCheckBox(tr("Right-to-left layout"));
+  {
+    tabLayout->setMargin(10);
+    tabLayout->setSpacing(5);
 
-  QVBoxLayout *tabLayout = new QVBoxLayout(tab);
-  tabLayout->setMargin(10);
-  tabLayout->setSpacing(5);
-  tabLayout->addWidget(loadImagesOn_);
-  tabLayout->addWidget(javaScriptEnable_);
-  tabLayout->addWidget(showDescriptionNews_);
-  tabLayout->addWidget(layoutDirection_);
-  tabLayout->addStretch();
+    loadImagesOn_ = new QCheckBox(tr("Load images"));
+    loadImagesOn_->setTristate(true);
+    javaScriptEnable_ = new QCheckBox(tr("Enable JavaScript"));
+    javaScriptEnable_->setTristate(true);
 
-  return tab;
+    showDescriptionNews_ = new QCheckBox(tr("Show news' description instead of loading web page"));
+
+    layoutDirection_ = new QCheckBox(tr("Right-to-left layout"));
+
+    tabLayout->addWidget(loadImagesOn_);
+    tabLayout->addWidget(javaScriptEnable_);
+    tabLayout->addWidget(showDescriptionNews_);
+    tabLayout->addWidget(layoutDirection_);
+
+    tabLayout->addStretch();
+  }
+
+  return returnVal;
 }
 //------------------------------------------------------------------------------
 QWidget *FeedPropertiesDialog::createColumnsTab()
@@ -373,6 +403,15 @@ QWidget *FeedPropertiesDialog::createStatusTab()
   starredOn_->setChecked(feedProperties.general.starred);
   duplicateNewsMode_->setChecked(feedProperties.general.duplicateNewsMode);
 
+  int curClickValIdx = singleClickAction->findData((int)feedProperties.mouse.singleClickAction);
+  singleClickAction->setCurrentIndex(curClickValIdx);
+
+  curClickValIdx = singleClickAction->findData((int)feedProperties.mouse.doubleClickAction);
+  doubleClickAction->setCurrentIndex(curClickValIdx);
+
+  curClickValIdx = singleClickAction->findData((int)feedProperties.mouse.middleClickAction);
+  middleClickAction->setCurrentIndex(curClickValIdx);
+
   loadImagesOn_->setCheckState((Qt::CheckState)feedProperties.display.displayEmbeddedImages);
   javaScriptEnable_->setCheckState((Qt::CheckState)feedProperties.display.javaScriptEnable);
   showDescriptionNews_->setChecked(!feedProperties.display.displayNews);
@@ -506,6 +545,10 @@ FEED_PROPERTIES FeedPropertiesDialog::getFeedProperties()
   feedProperties.general.updateEnable = updateEnable_->isChecked();
   feedProperties.general.updateInterval = updateInterval_->value();
   feedProperties.general.intervalType = updateIntervalType_->currentIndex() - 1;
+
+  feedProperties.mouse.singleClickAction = (ENewsClickAction::Type)singleClickAction->currentData().toInt();
+  feedProperties.mouse.doubleClickAction = (ENewsClickAction::Type)doubleClickAction->currentData().toInt();
+  feedProperties.mouse.middleClickAction = (ENewsClickAction::Type)middleClickAction->currentData().toInt();
 
   feedProperties.general.displayOnStartup = displayOnStartup->isChecked();
   feedProperties.general.starred = starredOn_->isChecked();

--- a/src/feedpropertiesdialog.h
+++ b/src/feedpropertiesdialog.h
@@ -21,6 +21,7 @@
 #include "dialog.h"
 #include "lineedit.h"
 #include "toolbutton.h"
+#include "optionsdialog.h"
 
 //! Feed properties structure
 typedef struct {
@@ -112,6 +113,14 @@ typedef struct {
     int feedsCount; //!< Number of feeds
   } status;
 
+  //! Mouse properties
+  struct mouse
+  {
+    ENewsClickAction::Type singleClickAction;  //!< Action to take on single click
+    ENewsClickAction::Type doubleClickAction;  //!< Action to take on double click
+    ENewsClickAction::Type middleClickAction;  //!< Action to take on middle click
+  } mouse;
+
 } FEED_PROPERTIES;
 
 //! Feed properties dialog
@@ -162,6 +171,13 @@ private:
   QCheckBox *duplicateNewsMode_;
 
   QWidget *createGeneralTab();
+
+  // Tab "Mouse"
+  QComboBox* singleClickAction;
+  QComboBox* doubleClickAction;
+  QComboBox* middleClickAction;
+
+  QWidget* createMouseTab();
 
   // Tab "Display"
   QCheckBox *showDescriptionNews_;

--- a/src/newstabwidget.cpp
+++ b/src/newstabwidget.cpp
@@ -138,6 +138,9 @@ NewsTabWidget::NewsTabWidget(QWidget *parent, TabType type, int feedId, int feed
 
   connect(this, SIGNAL(signalSetTextTab(QString,NewsTabWidget*)),
           mainWindow_, SLOT(setTextTitle(QString,NewsTabWidget*)));
+
+  connect(&timerMouseClick, SIGNAL(timeout()), this, SLOT(slotMouseClickTimeout()));
+  timerMouseClick.setSingleShot(true);
 }
 
 NewsTabWidget::~NewsTabWidget()
@@ -665,11 +668,11 @@ void NewsTabWidget::setAutoLoadImages(bool apply)
  *----------------------------------------------------------------------------*/
 void NewsTabWidget::slotNewsViewClicked(QModelIndex index)
 {
-  slotNewsViewSelected(index);
+  handleMouseClick(index, Qt::LeftButton);
 }
 
 // ----------------------------------------------------------------------------
-void NewsTabWidget::slotNewsViewSelected(QModelIndex index, bool clicked)
+void NewsTabWidget::slotNewsViewSelected(QModelIndex index, bool clicked, bool bUpdateWebView/*=true*/)
 {
   if (mainWindow_->newsLayout_ == 1) return;
 
@@ -718,9 +721,11 @@ void NewsTabWidget::slotNewsViewSelected(QModelIndex index, bool clicked)
       mainWindow_->categoriesTree_->currentItem()->setText(3, QString::number(newsId));
     }
 
-    updateWebView(index);
-
-    mainWindow_->statusBar()->showMessage(linkNewsString_, 3000);
+    if (bUpdateWebView)
+    {
+      updateWebView(index);
+      mainWindow_->statusBar()->showMessage(linkNewsString_, 3000);
+    }
   }
   currentNewsIdOld = newsId;
 }
@@ -728,30 +733,13 @@ void NewsTabWidget::slotNewsViewSelected(QModelIndex index, bool clicked)
 // ----------------------------------------------------------------------------
 void NewsTabWidget::slotNewsViewDoubleClicked(QModelIndex index)
 {
-  if (!index.isValid()) return;
-
-  QUrl url = QUrl::fromEncoded(getLinkNews(index.row()).toUtf8());
-  slotLinkClicked(url);
+  handleMouseClick(index, Qt::LeftButton, true);
 }
 
 // ----------------------------------------------------------------------------
 void NewsTabWidget::slotNewsMiddleClicked(QModelIndex index)
 {
-  if (!index.isValid()) return;
-
-  if (mainWindow_->markNewsReadOn_ && mainWindow_->markCurNewsRead_)
-    slotSetItemRead(index, 1);
-
-  if (QApplication::keyboardModifiers() == Qt::NoModifier) {
-    webView_->buttonClick_ = MIDDLE_BUTTON;
-  } else if (QApplication::keyboardModifiers() == Qt::AltModifier) {
-    webView_->buttonClick_ = LEFT_BUTTON_ALT;
-  } else {
-    webView_->buttonClick_ = MIDDLE_BUTTON_MOD;
-  }
-
-  QUrl url = QUrl::fromEncoded(getLinkNews(index.row()).toUtf8());
-  slotLinkClicked(url);
+  handleMouseClick(index, Qt::MiddleButton);
 }
 
 /** @brief Process pressing UP-key
@@ -1329,194 +1317,306 @@ void NewsTabWidget::slotSort(int column, int/* order*/)
  *----------------------------------------------------------------------------*/
 void NewsTabWidget::updateWebView(QModelIndex index)
 {
-  if (!index.isValid()) {
+  if (!index.isValid())
+  {
     hideWebContent();
     return;
   }
 
-  QString newsId = newsModel_->dataField(index.row(), "id").toString();
-  linkNewsString_ = getLinkNews(index.row());
-  QString linkString = linkNewsString_;
-  QUrl newsUrl = QUrl::fromEncoded(linkString.toUtf8());
 
   bool showDescriptionNews_ = mainWindow_->showDescriptionNews_;
-
   QModelIndex currentIndex = feedsProxyModel_->mapToSource(feedsView_->currentIndex());
   QVariant displayNews = feedsModel_->dataField(currentIndex, "displayNews");
+
   if (!displayNews.toString().isEmpty())
+  {
     showDescriptionNews_ = !displayNews.toInt();
+  }
 
-  if (!showDescriptionNews_) {
-    if (mainWindow_->externalBrowserOn_ <= 0) {
-      locationBar_->setText(newsUrl.toString());
-      setWebToolbarVisible(true, false);
+  if (showDescriptionNews_)
+  {
+    updateWebView_Description(index);
+  }
+  else
+  {
+    updateWebView_Link(index, (mainWindow_->externalBrowserOn_ > 0));
+  }
+}
 
-      webView_->history()->setMaximumItemCount(0);
-      webView_->load(newsUrl);
-      webView_->history()->setMaximumItemCount(100);
-    } else {
-      openUrl(newsUrl);
+void NewsTabWidget::updateWebView_Link(QModelIndex index, bool bExternalLink/*=false*/, QString overrideURL/*=""*/)
+{
+  if (!index.isValid())
+  {
+    hideWebContent();
+    return;
+  }
+
+
+  linkNewsString_ = getLinkNews(index.row());
+
+  QUrl newsUrl = QUrl::fromEncoded((overrideURL.isEmpty() ? linkNewsString_ : overrideURL).toUtf8());
+
+  if (bExternalLink)
+  {
+    openUrl(newsUrl);
+  }
+  else
+  {
+    locationBar_->setText(newsUrl.toString());
+    setWebToolbarVisible(true, false);
+
+    webView_->history()->setMaximumItemCount(0);
+    webView_->load(newsUrl);
+    webView_->history()->setMaximumItemCount(100);
+  }
+}
+
+void NewsTabWidget::updateWebView_Description(QModelIndex index)
+{
+  if (!index.isValid())
+  {
+    hideWebContent();
+    return;
+  }
+
+
+  setWebToolbarVisible(false, false);
+
+  linkNewsString_ = getLinkNews(index.row());
+
+
+  QString htmlString = "";
+  QUrl url;
+
+  generateDescriptionHtml(index, htmlString, url);
+
+  emit signalSetHtmlWebView(htmlString, url);
+}
+
+void NewsTabWidget::generateDescriptionHtml(QModelIndex index, QString& outHtml, QUrl& outURL)
+{
+  QString linkString = getLinkNews(index.row());
+  QUrl newsUrl = QUrl::fromEncoded(linkString.toUtf8());
+
+  outURL.setScheme(newsUrl.scheme());
+  outURL.setHost(newsUrl.host());
+
+  QString newsId = newsModel_->dataField(index.row(), "id").toString();
+  QString content = newsModel_->dataField(index.row(), "content").toString();
+
+  if (!content.contains(QRegExp("<html(.*)</html>", Qt::CaseInsensitive, QRegExp::RegExp2)))
+  {
+    QString description = newsModel_->dataField(index.row(), "description").toString();
+
+    if (content.isEmpty() || (description.length() > content.length()))
+    {
+      content = description;
     }
-  } else {
-    setWebToolbarVisible(false, false);
 
-    QString htmlStr;
-    QString content = newsModel_->dataField(index.row(), "content").toString();
-    if (!content.contains(QRegExp("<html(.*)</html>", Qt::CaseInsensitive, QRegExp::RegExp2))) {
-      QString description = newsModel_->dataField(index.row(), "description").toString();
-      if (content.isEmpty() || (description.length() > content.length())) {
-        content = description;
-      }
+    QString feedId = newsModel_->dataField(index.row(), "feedId").toString();
+    QModelIndex feedIndex = feedsModel_->indexById(feedId.toInt());
+    QString titleString = newsModel_->dataField(index.row(), "title").toString();
 
-      QString feedId = newsModel_->dataField(index.row(), "feedId").toString();
-      QModelIndex feedIndex = feedsModel_->indexById(feedId.toInt());
+    if (!linkString.isEmpty())
+    {
+      titleString = QString("<a href='%1' class='unread'>%2</a>").arg(linkString, titleString);
+    }
 
-      QString titleString = newsModel_->dataField(index.row(), "title").toString();
-      if (!linkString.isEmpty()) {
-        titleString = QString("<a href='%1' class='unread'>%2</a>").
-            arg(linkString, titleString);
-      }
+    QDateTime dtLocal;
+    QString dateString = newsModel_->dataField(index.row(), "published").toString();
 
-      QDateTime dtLocal;
-      QString dateString = newsModel_->dataField(index.row(), "published").toString();
-      if (!dateString.isNull()) {
-        QDateTime dtLocalTime = QDateTime::currentDateTime();
-        QDateTime dtUTC = QDateTime(dtLocalTime.date(), dtLocalTime.time(), Qt::UTC);
-        int nTimeShift = dtLocalTime.secsTo(dtUTC);
+    if (!dateString.isNull())
+    {
+      QDateTime dtLocalTime = QDateTime::currentDateTime();
+      QDateTime dtUTC = QDateTime(dtLocalTime.date(), dtLocalTime.time(), Qt::UTC);
+      int nTimeShift = dtLocalTime.secsTo(dtUTC);
 
-        QDateTime dt = QDateTime::fromString(dateString, Qt::ISODate);
-        dtLocal = dt.addSecs(nTimeShift);
-      } else {
-        dtLocal = QDateTime::fromString(
-              newsModel_->dataField(index.row(), "received").toString(),
-              Qt::ISODate);
-      }
-      if (QDateTime::currentDateTime().date() <= dtLocal.date())
-        dateString = dtLocal.toString(mainWindow_->formatTime_);
-      else
-        dateString = dtLocal.toString(mainWindow_->formatDate_ + " " + mainWindow_->formatTime_);
+      QDateTime dt = QDateTime::fromString(dateString, Qt::ISODate);
+      dtLocal = dt.addSecs(nTimeShift);
+    }
+    else
+    {
+      dtLocal = QDateTime::fromString(newsModel_->dataField(index.row(), "received").toString(), Qt::ISODate);
+    }
 
-      // Create author panel from news author
-      QString authorString;
-      QString authorName = newsModel_->dataField(index.row(), "author_name").toString();
-      QString authorEmail = newsModel_->dataField(index.row(), "author_email").toString();
-      QString authorUri = newsModel_->dataField(index.row(), "author_uri").toString();
+    if (QDateTime::currentDateTime().date() <= dtLocal.date())
+    {
+      dateString = dtLocal.toString(mainWindow_->formatTime_);
+    }
+    else
+    {
+      dateString = dtLocal.toString(mainWindow_->formatDate_ + " " + mainWindow_->formatTime_);
+    }
 
-      QRegExp reg("(^\\S+@\\S+\\.\\S+)", Qt::CaseInsensitive, QRegExp::RegExp2);
-      int pos = reg.indexIn(authorName);
-      if (pos > -1) {
-        authorName.replace(reg.cap(1), QString(" <a href='mailto:%1'>%1</a>").arg(reg.cap(1)));
-      }
+    // Create author panel from news author
+    QString authorString;
+    QString authorName = newsModel_->dataField(index.row(), "author_name").toString();
+    QString authorEmail = newsModel_->dataField(index.row(), "author_email").toString();
+    QString authorUri = newsModel_->dataField(index.row(), "author_uri").toString();
+
+    QRegExp reg("(^\\S+@\\S+\\.\\S+)", Qt::CaseInsensitive, QRegExp::RegExp2);
+    int pos = reg.indexIn(authorName);
+
+    if (pos > -1)
+    {
+      authorName.replace(reg.cap(1), QString(" <a href='mailto:%1'>%1</a>").arg(reg.cap(1)));
+    }
+
+    authorString = authorName;
+
+    if (!authorEmail.isEmpty())
+    {
+      authorString.append(QString(" <a href='mailto:%1'>e-mail</a>").arg(authorEmail));
+    }
+
+    if (!authorUri.isEmpty())
+    {
+      authorString.append(QString(" <a href='%1'>page</a>"). arg(authorUri));
+    }
+
+    // If news author is absent, create author panel from feed author
+    // @note(arhohryakov:2012.01.03) Author is got from current feed, because
+    //   news is belong to it
+    if (authorString.isEmpty())
+    {
+      authorName  = feedsModel_->dataField(feedIndex, "author_name").toString();
+      authorEmail = feedsModel_->dataField(feedIndex, "author_email").toString();
+      authorUri   = feedsModel_->dataField(feedIndex, "author_uri").toString();
+
       authorString = authorName;
 
       if (!authorEmail.isEmpty())
+      {
         authorString.append(QString(" <a href='mailto:%1'>e-mail</a>").arg(authorEmail));
+      }
+
       if (!authorUri.isEmpty())
-        authorString.append(QString(" <a href='%1'>page</a>"). arg(authorUri));
-
-      // If news author is absent, create author panel from feed author
-      // @note(arhohryakov:2012.01.03) Author is got from current feed, because
-      //   news is belong to it
-      if (authorString.isEmpty()) {
-        authorName  = feedsModel_->dataField(feedIndex, "author_name").toString();
-        authorEmail = feedsModel_->dataField(feedIndex, "author_email").toString();
-        authorUri   = feedsModel_->dataField(feedIndex, "author_uri").toString();
-
-        authorString = authorName;
-        if (!authorEmail.isEmpty())
-          authorString.append(QString(" <a href='mailto:%1'>e-mail</a>").arg(authorEmail));
-        if (!authorUri.isEmpty())
-          authorString.append(QString(" <a href='%1'>page</a>").arg(authorUri));
+      {
+        authorString.append(QString(" <a href='%1'>page</a>").arg(authorUri));
       }
-
-      QString commentsStr;
-      QString commentsUrl = newsModel_->dataField(index.row(), "comments").toString();
-      if (!commentsUrl.isEmpty()) {
-        commentsStr = QString("<a href=\"%1\"> %2</a>").arg(commentsUrl, tr("Comments"));
-      }
-
-      QString category = newsModel_->dataField(index.row(), "category").toString();
-
-      if (!authorString.isEmpty()) {
-        authorString = QString(tr("Author: %1")).arg(authorString);
-        if (!commentsStr.isEmpty())
-          authorString.append(QString(" | %1").arg(commentsStr));
-        if (!category.isEmpty())
-          authorString.append(QString(" | %1").arg(category));
-      } else {
-        if (!commentsStr.isEmpty())
-          authorString.append(commentsStr);
-        if (!category.isEmpty()) {
-          if (!commentsStr.isEmpty())
-            authorString.append(QString(" | %1").arg(category));
-          else
-            authorString.append(category);
-        }
-      }
-
-      QString labelsString = getHtmlLabels(index.row());
-      authorString.append(QString("<table class=\"labels\" id=\"labels%1\"><tr>%2</tr></table>").
-                          arg(newsId).arg(labelsString));
-
-      QString enclosureStr;
-      QString enclosureUrl = newsModel_->dataField(index.row(), "enclosure_url").toString();
-      if (!enclosureUrl.isEmpty()) {
-        QString type = newsModel_->dataField(index.row(), "enclosure_type").toString();
-        if (type.contains("image")) {
-          if (!content.contains(enclosureUrl) && autoLoadImages_) {
-            enclosureStr = QString("<IMG SRC=\"%1\" class=\"enclosureImg\"><p>").
-                arg(enclosureUrl);
-          }
-        } else {
-          if (type.contains("audio")) {
-            type = tr("audio");
-            enclosureStr = audioPlayerHtml_.arg(enclosureUrl);
-            enclosureStr.append("<p>");
-          }
-          else if (type.contains("video")) {
-            type = tr("video");
-            enclosureStr = videoPlayerHtml_.arg(enclosureUrl);
-            enclosureStr.append("<p>");
-          }
-          else type = tr("media");
-
-          enclosureStr.append(QString("<a href=\"%1\" class=\"enclosure\"> %2 %3 </a><p>").
-                              arg(enclosureUrl, tr("Link to"), type));
-        }
-      }
-
-      content = enclosureStr + content;
-
-      bool ltr = !feedsModel_->dataField(feedIndex, "layoutDirection").toInt();
-      QString cssStr = cssString_.
-          arg(ltr ? "left" : "right"). // text-align
-          arg(ltr ? "ltr" : "rtl"). // direction
-          arg(ltr ? "right" : "left"); // "Date" text-align
-
-      if (!autoLoadImages_) {
-        QRegExp reg("<img[^>]+>", Qt::CaseInsensitive, QRegExp::RegExp2);
-        content = content.remove(reg);
-      }
-
-      if (ltr)
-        htmlStr = htmlString_.arg(cssStr, titleString, dateString, authorString, content);
-      else
-        htmlStr = htmlRtlString_.arg(cssStr, titleString, dateString, authorString, content);
-    } else {
-      if (!autoLoadImages_) {
-        content = content.remove(QRegExp("<img[^>]+>", Qt::CaseInsensitive, QRegExp::RegExp2));
-      }
-
-      htmlStr = content;
     }
 
-    htmlStr = htmlStr.replace("src=\"//", "src=\"http://");
+    QString commentsStr;
+    QString commentsUrl = newsModel_->dataField(index.row(), "comments").toString();
 
-    QUrl url;
-    url.setScheme(newsUrl.scheme());
-    url.setHost(newsUrl.host());
-    emit signalSetHtmlWebView(htmlStr, url);
+    if (!commentsUrl.isEmpty())
+    {
+      commentsStr = QString("<a href=\"%1\"> %2</a>").arg(commentsUrl, tr("Comments"));
+    }
+
+    QString category = newsModel_->dataField(index.row(), "category").toString();
+
+    if (!authorString.isEmpty())
+    {
+      authorString = QString(tr("Author: %1")).arg(authorString);
+
+      if (!commentsStr.isEmpty())
+      {
+        authorString.append(QString(" | %1").arg(commentsStr));
+      }
+      if (!category.isEmpty())
+      {
+        authorString.append(QString(" | %1").arg(category));
+      }
+    }
+    else
+    {
+      if (!commentsStr.isEmpty())
+      {
+        authorString.append(commentsStr);
+      }
+
+      if (!category.isEmpty())
+      {
+        if (!commentsStr.isEmpty())
+        {
+          authorString.append(QString(" | %1").arg(category));
+        }
+        else
+        {
+          authorString.append(category);
+        }
+      }
+    }
+
+    QString labelsString = getHtmlLabels(index.row());
+
+    authorString.append(QString("<table class=\"labels\" id=\"labels%1\"><tr>%2</tr></table>").
+              arg(newsId).arg(labelsString));
+
+    QString enclosureStr;
+    QString enclosureUrl = newsModel_->dataField(index.row(), "enclosure_url").toString();
+
+    if (!enclosureUrl.isEmpty())
+    {
+      QString type = newsModel_->dataField(index.row(), "enclosure_type").toString();
+
+      if (type.contains("image"))
+      {
+        if (!content.contains(enclosureUrl) && autoLoadImages_)
+        {
+          enclosureStr = QString("<IMG SRC=\"%1\" class=\"enclosureImg\"><p>").arg(enclosureUrl);
+        }
+      }
+      else
+      {
+        if (type.contains("audio"))
+        {
+          type = tr("audio");
+          enclosureStr = audioPlayerHtml_.arg(enclosureUrl);
+          enclosureStr.append("<p>");
+        }
+        else if (type.contains("video"))
+        {
+          type = tr("video");
+          enclosureStr = videoPlayerHtml_.arg(enclosureUrl);
+          enclosureStr.append("<p>");
+        }
+        else
+        {
+          type = tr("media");
+        }
+
+        enclosureStr.append(QString("<a href=\"%1\" class=\"enclosure\"> %2 %3 </a><p>").
+                  arg(enclosureUrl, tr("Link to"), type));
+      }
+    }
+
+    content = enclosureStr + content;
+
+    bool ltr = !feedsModel_->dataField(feedIndex, "layoutDirection").toInt();
+
+    QString cssStr = cssString_.
+      arg(ltr ? "left" : "right").  // text-align
+      arg(ltr ? "ltr" : "rtl").    // direction
+      arg(ltr ? "right" : "left");  // "Date" text-align
+
+    if (!autoLoadImages_)
+    {
+      QRegExp reg("<img[^>]+>", Qt::CaseInsensitive, QRegExp::RegExp2);
+      content = content.remove(reg);
+    }
+
+    if (ltr)
+    {
+      outHtml = htmlString_.arg(cssStr, titleString, dateString, authorString, content);
+    }
+    else
+    {
+      outHtml = htmlRtlString_.arg(cssStr, titleString, dateString, authorString, content);
+    }
   }
+  else
+  {
+    if (!autoLoadImages_)
+    {
+      content = content.remove(QRegExp("<img[^>]+>", Qt::CaseInsensitive, QRegExp::RegExp2));
+    }
+
+    outHtml = content;
+  }
+
+  outHtml = outHtml.replace("src=\"//", "src=\"http://");
 }
 
 void NewsTabWidget::loadNewspaper(int refresh)
@@ -1795,20 +1895,26 @@ void NewsTabWidget::hideWebContent()
   setWebToolbarVisible(false, false);
 }
 
-void NewsTabWidget::slotLinkClicked(QUrl url)
+void NewsTabWidget::slotLinkClicked(QUrl url, bool bForceNewTab/*=false*/, bool bForceNewBkgTab/*=false*/,
+                                    QString* overrideHtml/*=NULL*/)
 {
-  if (url.scheme() == QLatin1String("quiterss")) {
+  if (url.scheme() == QLatin1String("quiterss"))
+  {
     actionNewspaper(url);
     return;
   }
 
-  if (url.scheme() == QLatin1String("mailto")) {
+  if (url.scheme() == QLatin1String("mailto"))
+  {
     QDesktopServices::openUrl(url);
     return;
   }
 
-  if (type_ != TabTypeWeb) {
-    if (url.host().isEmpty() && newsView_->currentIndex().isValid()) {
+
+  if (type_ != TabTypeWeb)
+  {
+    if (url.host().isEmpty() && newsView_->currentIndex().isValid())
+    {
       int row = newsView_->currentIndex().row();
       int feedId = newsModel_->dataField(row, "feedId").toInt();
       QModelIndex feedIndex = feedsModel_->indexById(feedId);
@@ -1819,33 +1925,76 @@ void NewsTabWidget::slotLinkClicked(QUrl url)
     }
   }
 
-  if ((mainWindow_->externalBrowserOn_ <= 0) &&
-      (webView_->buttonClick_ != LEFT_BUTTON_ALT)) {
-    if (webView_->buttonClick_ == LEFT_BUTTON) {
-      if (!webControlPanel_->isVisible()) {
-        locationBar_->setText(url.toString());
-        setWebToolbarVisible(true, false);
-      }
-      webView_->load(url);
-    } else {
-      if ((webView_->buttonClick_ == MIDDLE_BUTTON) ||
-          (webView_->buttonClick_ == LEFT_BUTTON_CTRL)) {
+  bool bLoadWebView = false;
+  bool bLoadNewTab = false;
+  bool bLoadExternal = false;
+
+  if (bForceNewTab)
+  {
+    mainWindow_->openNewsTab_ = NEW_TAB_FOREGROUND;
+    bLoadNewTab = true;
+  }
+  else if (bForceNewBkgTab)
+  {
+    mainWindow_->openNewsTab_ = NEW_TAB_BACKGROUND;
+    bLoadNewTab = true;
+  }
+  else if ((mainWindow_->externalBrowserOn_ <= 0) && (webView_->buttonClick_ != LEFT_BUTTON_ALT))
+  {
+    if (webView_->buttonClick_ == LEFT_BUTTON)
+    {
+      bLoadWebView = true;
+    }
+    else
+    {
+      if ((webView_->buttonClick_ == MIDDLE_BUTTON) || (webView_->buttonClick_ == LEFT_BUTTON_CTRL))
+      {
         mainWindow_->openNewsTab_ = NEW_TAB_BACKGROUND;
-      } else {
+      }
+      else
+      {
         mainWindow_->openNewsTab_ = NEW_TAB_FOREGROUND;
       }
-      if (!mainWindow_->openLinkInBackgroundEmbedded_) {
+
+      if (!mainWindow_->openLinkInBackgroundEmbedded_)
+      {
         if (mainWindow_->openNewsTab_ == NEW_TAB_BACKGROUND)
+        {
           mainWindow_->openNewsTab_ = NEW_TAB_FOREGROUND;
+        }
         else
+        {
           mainWindow_->openNewsTab_ = NEW_TAB_BACKGROUND;
+        }
       }
 
-      mainWindow_->createWebTab(url);
+      bLoadNewTab = true;
     }
-  } else {
+  }
+  else
+  {
+    bLoadExternal = true;
+  }
+
+  if (bLoadWebView)
+  {
+    if (!webControlPanel_->isVisible())
+    {
+      locationBar_->setText(url.toString());
+      setWebToolbarVisible(true, false);
+    }
+
+    webView_->load(url);
+  }
+  else if (bLoadNewTab)
+  {
+    mainWindow_->createWebTab(url, overrideHtml);
+  }
+  else // if (bLoadExternal)
+  {
     openUrl(url);
   }
+
   webView_->buttonClick_ = 0;
 }
 //----------------------------------------------------------------------------
@@ -2816,5 +2965,154 @@ void NewsTabWidget::actionNewspaper(QUrl url)
         newsItem.removeFromDocument();
       }
     }
+  }
+}
+
+void NewsTabWidget::handleMouseClick(QModelIndex index, Qt::MouseButton button, bool bDoubleClick/*=false*/)
+{
+  QModelIndex feedIndex = feedsModel_->indexById(feedId_);
+  ENewsClickAction::Type singleClickAction = (ENewsClickAction::Type)feedsModel_->dataField(feedIndex, "SingleClickAction").toInt();
+  ENewsClickAction::Type doubleClickAction = (ENewsClickAction::Type)feedsModel_->dataField(feedIndex, "DoubleClickAction").toInt();
+  ENewsClickAction::Type middleClickAction = (ENewsClickAction::Type)feedsModel_->dataField(feedIndex, "MiddleClickAction").toInt();
+
+  singleClickAction = (singleClickAction == ENewsClickAction::NCA_Default ? mainWindow_->newsSingleClickAction : singleClickAction);
+  doubleClickAction = (doubleClickAction == ENewsClickAction::NCA_Default ? mainWindow_->newsDoubleClickAction : doubleClickAction);
+  middleClickAction = (middleClickAction == ENewsClickAction::NCA_Default ? mainWindow_->newsMiddleClickAction : middleClickAction);
+
+  if (button == Qt::LeftButton && !bDoubleClick)
+  {
+    if (singleClickAction != ENewsClickAction::NCA_Nothing && !timerMouseClick.isActive())
+    {
+      // We do not know if this click, is the first click of a double click, so we don't want to do anything disruptive to the UI,
+      // until we know one way or the other - this means some single-click settings are safe to execute immediately,
+      // and some have to be delayed to rule-out a double-click (e.g. immediately showing news description is safe,
+      // but opening a new tab will have to be delayed)
+      bool bDelayAction = false;
+
+      if (singleClickAction != doubleClickAction && doubleClickAction != ENewsClickAction::NCA_Nothing)
+      {
+        bDelayAction = true;
+
+        if (singleClickAction == ENewsClickAction::NCA_Description || singleClickAction == ENewsClickAction::NCA_WebPage)
+        {
+          bDelayAction = false;
+        }
+      }
+
+      if (bDelayAction)
+      {
+        pendingClickIndex = index;
+        timerMouseClick.start(400);
+      }
+      else
+      {
+        performNewsClickAction(index, singleClickAction);
+      }
+    }
+  }
+  else if (button == Qt::LeftButton && bDoubleClick)
+  {
+    timerMouseClick.stop();
+
+    if (doubleClickAction != ENewsClickAction::NCA_Nothing)
+    {
+      performNewsClickAction(index, doubleClickAction);
+    }
+  }
+  else if (button == Qt::MiddleButton)
+  {
+    if (QApplication::keyboardModifiers() == Qt::NoModifier)
+    {
+      if (middleClickAction != ENewsClickAction::NCA_Nothing)
+      {
+        performNewsClickAction(index, middleClickAction);
+      }
+    }
+    else if (QApplication::keyboardModifiers() == Qt::AltModifier)
+    {
+      performNewsClickAction(index, ENewsClickAction::NCA_ExternalBrowser);
+    }
+    else
+    {
+      performNewsClickAction(index, ENewsClickAction::NCA_WebPageBkgTab);
+    }
+  }
+}
+
+void NewsTabWidget::slotMouseClickTimeout()
+{
+  if (pendingClickIndex.isValid())
+  {
+    QModelIndex feedIndex = feedsModel_->indexById(feedId_);
+    ENewsClickAction::Type singleClickAction =
+      (ENewsClickAction::Type)feedsModel_->dataField(feedIndex, "SingleClickAction").toInt();
+
+    singleClickAction = (singleClickAction == ENewsClickAction::NCA_Default ? mainWindow_->newsSingleClickAction :
+                          singleClickAction);
+    
+    performNewsClickAction(pendingClickIndex, singleClickAction);
+  }
+}
+
+void NewsTabWidget::performNewsClickAction(QModelIndex index, ENewsClickAction::Type action)
+{
+  if (index.isValid())
+  {
+    switch (action)
+    {
+      case ENewsClickAction::NCA_Description:
+      {
+        slotNewsViewSelected(index, false, false);
+        updateWebView_Description(index);
+
+        break;
+      }
+
+      case ENewsClickAction::NCA_DescriptionNewTab:
+      case ENewsClickAction::NCA_DescriptionBkgTab:
+      {
+        slotNewsViewSelected(index, false, false);
+
+        bool bForegroundTab = action == ENewsClickAction::NCA_DescriptionNewTab;
+        QString htmlString = "";
+        QUrl url;
+
+        generateDescriptionHtml(index, htmlString, url);
+        slotLinkClicked(url, bForegroundTab, !bForegroundTab, &htmlString);
+
+        break;
+      }
+
+      case ENewsClickAction::NCA_WebPage:
+      case ENewsClickAction::NCA_ExternalBrowser:
+      {
+        bool bExternalLink = action == ENewsClickAction::NCA_ExternalBrowser;
+
+        slotNewsViewSelected(index, false, false);
+        updateWebView_Link(index, bExternalLink);
+
+        break;
+      }
+
+      case ENewsClickAction::NCA_WebPageNewTab:
+      case ENewsClickAction::NCA_WebPageBkgTab:
+      {
+        slotNewsViewSelected(index, false, false);
+
+        bool bForegroundTab = action == ENewsClickAction::NCA_WebPageNewTab;
+        QUrl url = QUrl::fromEncoded(getLinkNews(index.row()).toUtf8());
+
+        slotLinkClicked(url, bForegroundTab, !bForegroundTab);
+
+        break;
+      }
+
+      default:
+      {
+        break;
+      }
+    }
+
+    mainWindow_->statusBar()->showMessage(linkNewsString_, 3000);
   }
 }

--- a/src/newstabwidget.h
+++ b/src/newstabwidget.h
@@ -36,6 +36,7 @@
 #include "newsmodel.h"
 #include "newsview.h"
 #include "webview.h"
+#include "optionsdialog.h"
 
 class MainWindow;
 
@@ -92,6 +93,9 @@ public:
   void openNewsNewTab();
 
   void updateWebView(QModelIndex index);
+  void updateWebView_Link(QModelIndex index, bool bExternalLink=false, QString overrideURL="");
+  void updateWebView_Description(QModelIndex index);
+  void generateDescriptionHtml(QModelIndex index, QString& outHtml, QUrl& outURL);
   void loadNewspaper(int refresh = RefreshAll);
   void hideWebContent();
   QString getLinkNews(int row);
@@ -143,7 +147,7 @@ public:
 public slots:
   void setAutoLoadImages(bool apply = true);
   void slotNewsViewClicked(QModelIndex index);
-  void slotNewsViewSelected(QModelIndex index, bool clicked = false);
+  void slotNewsViewSelected(QModelIndex index, bool clicked=false, bool bUpdateWebView=true);
   void slotNewsViewDoubleClicked(QModelIndex index);
   void slotNewsMiddleClicked(QModelIndex index);
   void slotNewsUpPressed(QModelIndex index=QModelIndex());
@@ -168,7 +172,7 @@ private slots:
   void setHtmlWebView(const QString &html, const QUrl &baseUrl);
   void webHomePage();
   void openPageInExternalBrowser();
-  void slotLinkClicked(QUrl url);
+  void slotLinkClicked(QUrl url, bool bForceNewTab=false, bool bForceNewBkgTab=false, QString* overrideHtml=NULL);
   void slotLinkHovered(const QString &link, const QString &str1="", const QString &str2="");
   void slotSetValue(int value);
   void slotLoadStarted();
@@ -190,11 +194,17 @@ private slots:
 
   void slotNewslLabelClicked(QModelIndex index);
 
+  void slotMouseClickTimeout();
+
 private:
   void createNewsList();
   void createWebWidget();
   QString getHtmlLabels(int row);
   void actionNewspaper(QUrl url);
+
+  void handleMouseClick(QModelIndex index, Qt::MouseButton button, bool bDoubleClick=false);
+
+  void performNewsClickAction(QModelIndex index, ENewsClickAction::Type action);
 
   MainWindow *mainWindow_;
   QSqlDatabase db_;
@@ -233,6 +243,8 @@ private:
   QString audioPlayerHtml_;
   QString videoPlayerHtml_;
 
+  QTimer timerMouseClick;
+  QPersistentModelIndex pendingClickIndex;
 };
 
 #endif // NEWSTABWIDGET_H

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -886,63 +886,92 @@ void OptionsDialog::createFeedsWidget()
   QWidget *generalFeedsWidget = new QWidget();
   generalFeedsWidget->setLayout(generalFeedsLayout);
 
-//! tab "Reading"
-  markNewsReadOn_ = new QGroupBox(tr("Mark news as read:"));
-  markNewsReadOn_->setCheckable(true);
-  markCurNewsRead_ = new QRadioButton(tr("on selecting. With timeout"));
-  markPrevNewsRead_ = new QRadioButton(tr("after switching to another news"));
-  markNewsReadTime_ = new QSpinBox();
-  markNewsReadTime_->setEnabled(false);
-  markNewsReadTime_->setRange(0, 100);
-  connect(markCurNewsRead_, SIGNAL(toggled(bool)),
+
+  //! tab "Reading"
+  QVBoxLayout* readingMainLayout = new QVBoxLayout();
+
+  {
+    markNewsReadOn_ = new QGroupBox(tr("Mark news as read:"));
+
+    markNewsReadOn_->setCheckable(true);
+
+    {
+      QVBoxLayout* radioLayout = new QVBoxLayout();
+
+      {
+        QHBoxLayout* curLayout = new QHBoxLayout();
+
+        markCurNewsRead_ = new QRadioButton(tr("on selecting. With timeout"));
+
+        markNewsReadTime_ = new QSpinBox();
+        markNewsReadTime_->setEnabled(false);
+        markNewsReadTime_->setRange(0, 100);
+        connect(markCurNewsRead_, SIGNAL(toggled(bool)),
           markNewsReadTime_, SLOT(setEnabled(bool)));
-  markReadSwitchingFeed_ = new QCheckBox(tr("Mark displayed news as read when switching feeds"));
-  markReadClosingTab_ = new QCheckBox(tr("Mark displayed news as read when closing tab"));
-  markReadMinimize_ = new QCheckBox(tr("Mark displayed news as read on minimize"));
 
-  showDescriptionNews_ = new QCheckBox(
-        tr("Show news description instead of loading web page"));
+        curLayout->setMargin(0);
+        curLayout->addWidget(markCurNewsRead_);
+        curLayout->addWidget(markNewsReadTime_);
+        curLayout->addWidget(new QLabel(tr("seconds")));
+        curLayout->addStretch();
 
-  changeBehaviorActionNUN_ = new QCheckBox(tr("Change behavior of action 'Next Unread News'"));
+        radioLayout->addLayout(curLayout);
+      }
 
-  notDeleteStarred_ = new QCheckBox(tr("starred news"));
-  notDeleteLabeled_ = new QCheckBox(tr("labeled news"));
+      markPrevNewsRead_ = new QRadioButton(tr("after switching to another news"));
 
-  markIdenticalNewsRead_ = new QCheckBox(tr("Automatically mark identical news as read"));
+      radioLayout->addWidget(markPrevNewsRead_);
+      markNewsReadOn_->setLayout(radioLayout);
+    }
 
-  QHBoxLayout *readingFeedsLayout1 = new QHBoxLayout();
-  readingFeedsLayout1->setMargin(0);
-  readingFeedsLayout1->addWidget(markCurNewsRead_);
-  readingFeedsLayout1->addWidget(markNewsReadTime_);
-  readingFeedsLayout1->addWidget(new QLabel(tr("seconds")));
-  readingFeedsLayout1->addStretch();
+    readingMainLayout->addWidget(markNewsReadOn_);
 
-  QVBoxLayout *readingFeedsLayout2 = new QVBoxLayout();
-  readingFeedsLayout2->addLayout(readingFeedsLayout1);
-  readingFeedsLayout2->addWidget(markPrevNewsRead_);
-  markNewsReadOn_->setLayout(readingFeedsLayout2);
 
-  QGridLayout *readingFeedsLayout3 = new QGridLayout();
-  readingFeedsLayout3->setContentsMargins(15, 0, 0, 10);
-  readingFeedsLayout3->addWidget(notDeleteStarred_, 0, 0, 1, 1);
-  readingFeedsLayout3->addWidget(notDeleteLabeled_, 1, 0, 1, 1);
+    markReadSwitchingFeed_ = new QCheckBox(tr("Mark displayed news as read when switching feeds"));
+    markReadClosingTab_ = new QCheckBox(tr("Mark displayed news as read when closing tab"));
+    markReadMinimize_ = new QCheckBox(tr("Mark displayed news as read on minimize"));
 
-  QVBoxLayout *readingFeedsLayout = new QVBoxLayout();
-  readingFeedsLayout->addWidget(markNewsReadOn_);
-  readingFeedsLayout->addWidget(markReadSwitchingFeed_);
-  readingFeedsLayout->addWidget(markReadClosingTab_);
-  readingFeedsLayout->addWidget(markReadMinimize_);
-  readingFeedsLayout->addSpacing(10);
-  readingFeedsLayout->addWidget(showDescriptionNews_);
-  readingFeedsLayout->addSpacing(10);
-  readingFeedsLayout->addWidget(new QLabel(tr("Prevent accidental deletion of:")));
-  readingFeedsLayout->addLayout(readingFeedsLayout3);
-  readingFeedsLayout->addWidget(changeBehaviorActionNUN_);
-  readingFeedsLayout->addWidget(markIdenticalNewsRead_);
-  readingFeedsLayout->addStretch();
+    showDescriptionNews_ = new QCheckBox(tr("Show news description instead of loading web page"));
 
-  QWidget *readingFeedsWidget = new QWidget();
-  readingFeedsWidget->setLayout(readingFeedsLayout);
+    readingMainLayout->addWidget(markReadSwitchingFeed_);
+    readingMainLayout->addWidget(markReadClosingTab_);
+    readingMainLayout->addWidget(markReadMinimize_);
+    readingMainLayout->addSpacing(10);
+    readingMainLayout->addWidget(showDescriptionNews_);
+
+    QWidget* clickActionWidgets = createClickActionWidgets(singleClickAction, doubleClickAction, middleClickAction);
+
+    readingMainLayout->addWidget(clickActionWidgets);
+    readingMainLayout->addSpacing(10);
+    readingMainLayout->addWidget(new QLabel(tr("Prevent accidental deletion of:")));
+
+
+    {
+      QGridLayout* curLayout = new QGridLayout();
+
+      notDeleteStarred_ = new QCheckBox(tr("starred news"));
+      notDeleteLabeled_ = new QCheckBox(tr("labeled news"));
+
+      curLayout->setContentsMargins(15, 0, 0, 10);
+      curLayout->addWidget(notDeleteStarred_, 0, 0, 1, 1);
+      curLayout->addWidget(notDeleteLabeled_, 1, 0, 1, 1);
+
+      readingMainLayout->addLayout(curLayout);
+    }
+
+    changeBehaviorActionNUN_ = new QCheckBox(tr("Change behavior of action 'Next Unread News'"));
+    markIdenticalNewsRead_ = new QCheckBox(tr("Automatically mark identical news as read"));
+
+    readingMainLayout->addWidget(changeBehaviorActionNUN_);
+    readingMainLayout->addWidget(markIdenticalNewsRead_);
+  }
+
+  readingMainLayout->addStretch();
+
+  QWidget* readingFeedsWidget = new QWidget();
+
+  readingFeedsWidget->setLayout(readingMainLayout);
+
 
 //! tab "Clean Up"
   QWidget *cleanUpFeedsWidget = new QWidget();
@@ -1000,6 +1029,91 @@ void OptionsDialog::createFeedsWidget()
   feedsWidget_->addTab(generalFeedsWidget, tr("General"));
   feedsWidget_->addTab(readingFeedsWidget, tr("Reading"));
   feedsWidget_->addTab(cleanUpFeedsWidget, tr("Clean Up"));
+}
+
+QWidget* OptionsDialog::createClickActionWidgets(QComboBox*& outSingleClickAction, QComboBox*& outDoubleClickAction,
+                                                  QComboBox*& outMiddleClickAction, bool bAddDefaultValue/*=false*/)
+{
+  // @todo #JohnBTranslation
+  QGroupBox* returnVal = new QGroupBox(tr("Action on news opening:"));
+
+  {
+    QHBoxLayout* actionLayoutLeft = new QHBoxLayout();
+    QHBoxLayout* actionLayoutRight = new QHBoxLayout();
+
+    {
+      QVBoxLayout* namesLayout = new QVBoxLayout();
+      QVBoxLayout* valuesLayout = new QVBoxLayout();
+
+      {
+        struct Local
+        {
+          static void setupCombo(QComboBox*& outCombo, bool bAddDefaultValue)
+          {
+            outCombo = new QComboBox();
+
+            if (bAddDefaultValue)
+            {
+              // @todo #JohnBTranslation
+              outCombo->addItem("Default", (int)ENewsClickAction::NCA_Default);
+              outCombo->insertSeparator(outCombo->count());
+            }
+
+            // @todo #JohnBTranslation
+            outCombo->addItem("Nothing", (int)ENewsClickAction::NCA_Nothing);
+            outCombo->insertSeparator(outCombo->count());
+
+            // @todo #JohnBTranslation
+            outCombo->addItem("Show News Description", (int)ENewsClickAction::NCA_Description);
+            // @todo #JohnBTranslation
+            outCombo->addItem("Show News Description in New Tab", (int)ENewsClickAction::NCA_DescriptionNewTab);
+            // @todo #JohnBTranslation
+            outCombo->addItem("Show News Description in New Tab (Background)",
+                      (int)ENewsClickAction::NCA_DescriptionBkgTab);
+            outCombo->insertSeparator(outCombo->count());
+
+            // @todo #JohnBTranslation
+            outCombo->addItem("Load Web Page", (int)ENewsClickAction::NCA_WebPage);
+            // @todo #JohnBTranslation
+            outCombo->addItem("Load Web Page in New Tab", (int)ENewsClickAction::NCA_WebPageNewTab);
+            // @todo #JohnBTranslation
+            outCombo->addItem("Load Web Page in New Tab (Background)", (int)ENewsClickAction::NCA_WebPageBkgTab);
+            outCombo->insertSeparator(outCombo->count());
+
+            // @todo #JohnBTranslation
+            outCombo->addItem("Open in External Browser", (int)ENewsClickAction::NCA_ExternalBrowser);
+          };
+        };
+
+        Local::setupCombo(outSingleClickAction, bAddDefaultValue);
+        Local::setupCombo(outDoubleClickAction, bAddDefaultValue);
+        Local::setupCombo(outMiddleClickAction, bAddDefaultValue);
+
+        // @todo #JohnBTranslation
+        namesLayout->addWidget(new QLabel(tr("Single Click:")));
+        valuesLayout->addWidget(outSingleClickAction);
+
+        // @todo #JohnBTranslation
+        namesLayout->addWidget(new QLabel(tr("Double Click:")));
+        valuesLayout->addWidget(outDoubleClickAction);
+
+        // @todo #JohnBTranslation
+        namesLayout->addWidget(new QLabel(tr("Middle Click:")));
+        valuesLayout->addWidget(outMiddleClickAction);
+      }
+
+
+      actionLayoutLeft->addLayout(namesLayout);
+      actionLayoutRight->addLayout(valuesLayout);
+    }
+
+    actionLayoutRight->addStretch();
+    actionLayoutLeft->addLayout(actionLayoutRight);
+
+    returnVal->setLayout(actionLayoutLeft);
+  }
+
+  return returnVal;
 }
 
 /** @brief Create widget "Labels"

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -30,13 +30,44 @@
 #include "lineedit.h"
 #include "notificationswidget.h"
 
+
+// Forward declarations
+class FeedPropertiesDialog;
+
+
 #define STATIC_ICON_TRAY        0
 #define CHANGE_ICON_TRAY        1
 #define NEW_COUNT_ICON_TRAY     2
 #define UNREAD_COUNT_ICON_TRAY  3
 
+/**
+ * Action to take upon clicking a news entry
+ * NOTE: Don't change value of 'Default' away from 0
+ */
+namespace ENewsClickAction
+{
+  enum Type
+  {
+    NCA_Start             = 0,
+
+    NCA_Default           = 0,
+    NCA_Nothing           = 1,
+    NCA_Description       = 2,
+    NCA_DescriptionNewTab = 3,
+    NCA_DescriptionBkgTab = 4,
+    NCA_WebPage           = 5,
+    NCA_WebPageNewTab     = 6,
+    NCA_WebPageBkgTab     = 7,
+    NCA_ExternalBrowser   = 8,
+
+    NCA_Max
+  };
+}
+
 class OptionsDialog : public Dialog
 {
+  friend class FeedPropertiesDialog;
+
   Q_OBJECT
 public:
   explicit OptionsDialog(QWidget *parent);
@@ -128,6 +159,10 @@ public:
   QCheckBox *markReadMinimize_;
 
   QCheckBox *showDescriptionNews_;
+
+  QComboBox* singleClickAction;
+  QComboBox* doubleClickAction;
+  QComboBox* middleClickAction;
 
   QComboBox *formatDate_;
   QComboBox *formatTime_;
@@ -315,6 +350,18 @@ private:
 
   // feeds
   void createFeedsWidget();
+
+  /**
+   * Creates the widgets for configuring news mouse click settings; shared between options dialog and feed properties dialog.
+   *
+   * @param outSingleClickAction  Variable storing the single click widget
+   * @param outDoubleClickAction  Variable storing the double click widget
+   * @param outMiddleClickAction  Variable storing the middle click widget
+   * @param bAddDefaultValue      Adds a value marked 'Default' to the combo box (for feed properties)
+   * @return                      Returns the widget for configuring the mouse settings
+   */
+  static QWidget* createClickActionWidgets(QComboBox*& outSingleClickAction, QComboBox*& outDoubleClickAction,
+                        QComboBox*& outMiddleClickAction, bool bAddDefaultValue=false);
 
   // notifier
   void createNotifierWidget();


### PR DESCRIPTION
- Can configure Single/Double/Middle click buttons
- Determines whether click opens description, web page, in new/background tab or webview, or in external browser
- Can configure global settings in Options->Feeds->Reading
- Can configure per-feed settings in Properties->Mouse
- 'Show news description instead of loading web page' option no longer affects mouse, only keyboard

Relates to issue #815.
