### PR TITLE
Don’t hardcode non-configurable preference for English language

### DIFF
--- a/src/requestfeed.cpp
+++ b/src/requestfeed.cpp
@@ -155,7 +155,6 @@ void RequestFeed::slotHead(const QUrl &getUrl, const int &id, const QString &fee
   QString userAgent = QString("Mozilla/5.0 (Windows NT 6.1) AppleWebKit/%1 (KHTML, like Gecko) QuiteRSS/%2 Safari/%1").
       arg(qWebKitVersion()).arg(STRPRODUCTVER);
   request.setRawHeader("User-Agent", userAgent.toUtf8());
-  request.setRawHeader("Accept-Language", "*,en-us;q=0.8,en;q=0.6");
 
   currentUrls_.append(getUrl);
   currentIds_.append(id);


### PR DESCRIPTION
This header doesn’t need to be sent, it’s redundant (as * is given quality 1.0), and it’s non-configurable.