### PR TITLE
Fix crash on startup when XDG_RUNTIME_DIR is not set.

### DIFF
--- a/src/application/logfile.cpp
+++ b/src/application/logfile.cpp
@@ -33,6 +33,9 @@ void LogFile::msgHandler(QtMsgType type, const QMessageLogContext &, const QStri
     if (mainApp->isNoDebugOutput()) return;
   }
 
+  if (!mainApp->dataDirInitialized())
+    return;
+
   QFile file;
   file.setFileName(mainApp->dataDir() + "/debug.log");
   QIODevice::OpenMode openMode = QIODevice::WriteOnly | QIODevice::Text;

--- a/src/application/mainapplication.cpp
+++ b/src/application/mainapplication.cpp
@@ -191,6 +191,7 @@ void MainApplication::checkDir()
     dataDir_ = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
     cacheDir_ = QDesktopServices::storageLocation(QDesktopServices::CacheLocation);
 #endif
+    dataDirInitialized_ = true;
     soundNotifyDir_ = resourcesDir_ % "/sound";
 
     QDir dir(dataDir_);

--- a/src/application/mainapplication.h
+++ b/src/application/mainapplication.h
@@ -51,6 +51,7 @@ public:
   bool isClosing() const;
   bool isNoDebugOutput() const { return noDebugOutput_; }
   void showClosingWidget();
+  bool dataDirInitialized() const { return dataDirInitialized_; }
 
   QString resourcesDir() const;
   QString dataDir() const;
@@ -111,6 +112,7 @@ private:
   bool isPortable_;
   bool isPortableAppsCom_;
   bool isClosing_;
+  bool dataDirInitialized_ = false;
 
   QString resourcesDir_;
   QString dataDir_;


### PR DESCRIPTION
In Qt 5.8, a message is logged when QStandardPaths::writableLocation() is
called for the first time, telling you that XDG_RUNTIME_DIR is not set.
QuiteRSS tries to log this to the dataDir, but we called
QStandardPaths::writeableLocation() while *initializing* the dataDir.
So we try to return an uninitialized QString member, and crash horribly.

This is a crude fix that tracks whether the dataDir is initialized yet,
and if it's not, just skips logging messages entirely. (It might be nicer
to print them to stderr, but that might also be ugly... maybe we should
do that, but only in debugging mode? I'm not sure.)