### PR TITLE
fix: Spelling correction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,7 +14,7 @@ Version 0.18.5 (15 Jun 2017)
 
 Version 0.18.4 (08 Mar 2016)
   * Changed: Mouse buttons settings of opening news is removed
-  * Changed: SQLite librari is updated to 3.11.1 version
+  * Changed: SQLite library is updated to 3.11.1 version
   * Fixed: msvcr120.dll troubles (Windows)
   * Fixed: Application crash while using some shortcuts
   * Fixed: Images are not displayed in some feeds
@@ -25,14 +25,14 @@ Version 0.18.3 (26 Jan 2015)
   * Changed: Update SQLite library to 3.9.2 version
   * Changed: Updating news in newspaper view using descending sort
   * Fixed: Duplicate notification sound playback (Ubuntu)
-  * Fixed: Application crash if quit while settins dialog is open
+  * Fixed: Application crash if quit while settings dialog is open
   * Fixed: Application crash while using search and filters
   * Fixed: Application crash while adding local feed
   * Fixed: News publish time of some feeds
 
 Version 0.18.2 (14 Jul 2015)
   * Fixed: Application crash
-  * Fixed: Catefories. Popup menu item "Mark as Read"
+  * Fixed: Categories. Popup menu item "Mark as Read"
 
 Version 0.18.1 (12 Jul 2015)
   * Fixed: Application crash
@@ -66,8 +66,8 @@ Version 0.17.7 (19 Apr 2015)
   * Added: Tray menu item "Add feed..."
   * Added: News filter. Condition "News" (title + description)
   * Added: Displaying feed icon beside feed title when using newspaper mode
-  * Added: Catefories. Popup menu item "Mark as Read"
-  * Changed: CA sertificate loading
+  * Added: Categories. Popup menu item "Mark as Read"
+  * Changed: CA certificate loading
   * Changed: Icons correction
   * Changed: Displaying the wizard only if feed is added from Firefox
   * Fixed: Occasional capturing of links while scrolling

--- a/HISTORY_EN
+++ b/HISTORY_EN
@@ -574,7 +574,7 @@
 <li>Fixed: Recounting feeds count after group operations</li>
 <li>Fixed: Moving tab content while moving tabs</li>
 <li>Fixed: Deleting default buttons from toolbar</li>
-<li>Fixed: Application startup in  Archlinux (KDE)</li>
+<li>Fixed: Application startup in Archlinux (KDE)</li>
 <li>Fixed: Show on top in full screen mode</li>
 <li>Fixed: Loop while adding/updating feed</li>
 <li>Fixed: Updating some feeds</li>

--- a/HISTORY_RU
+++ b/HISTORY_RU
@@ -99,7 +99,7 @@
 <li>Изменено: Корректировка иконок</li>
 <li>Изменено: При добавлении ленты из Firefox отображается только мастер</li>
 
-<li>Исправлено: Случайный захват ссылок при скролинге страницы</li>
+<li>Исправлено: Случайный захват ссылок при скроллинге страницы</li>
 <li>Исправлено: Нельзя вызвать программу из трея с помощью клавиш WIN+B (Windows)</li>
 <li>Исправлено: Некоторые ссылки на контент в содержимом новости не имеют схемы ("http")</li>
 </ul>
@@ -168,7 +168,7 @@
 <li>Добавлено: Настройка цвета текста и фона уведомления</li>
 <li>Добавлено: Опция уведомления "Показывать при неактивности главного окна"</li>
 <li>Добавлено: Дополнительные опции для настройки макета уведомления</li>
-<li>Добавлено: Горячие клавиши постраничного скроллига во встроенном браузере</li>
+<li>Добавлено: Горячие клавиши постраничного скроллинга во встроенном браузере</li>
 
 <li>Изменено: При переключении между лентами поиск в новостях не сбрасывается</li>
 <li>Изменено: После завершения мастера очистки отображается количество удалённых новостей</li>
@@ -825,7 +825,7 @@
 <!---------------------------------------------------------------------------->
 <p><b>Версия 0.9.1</b> (31 Май 2012)
 <ul>
-<li>Note: Повторное отображение новостей, которые уже были помечаны прочитанными (0.8.x -> 0.9.x) (<a href="https://code.google.com/p/quite-rss/wiki/ReappearNews">More...</a>)</li>
+<li>Note: Повторное отображение новостей, которые уже были помечены прочитанными (0.8.x -> 0.9.x) (<a href="https://code.google.com/p/quite-rss/wiki/ReappearNews">More...</a>)</li>
 
 <li>Added: Вкладки. Открытие ленты в новой вкладке</li>
 <li>Added: Изменение положения браузера("Вид->Позиция браузера")</li>
@@ -844,7 +844,7 @@
 <ul>
 <li>Main: Реконструкция базы данных (<a href="https://code.google.com/p/quite-rss/wiki/DatabaseReconstruction">More...</a>)</li>
 
-<li>Added: Опция: дествия при открытии ленты</li>
+<li>Added: Опция: действия при открытии ленты</li>
 <li>Added: Дополнительные горячие клавиши</li>
 <li>Added: Венгерский язык</li>
 
@@ -957,7 +957,7 @@
 <li>Fixed: Cyrillic letters in application path</li>
 <li>Fixed: SQLite for Qt 4.8.0</li>
 <li>Fixed: NetworkManager move to his own thread</li>
-<li>Fixed: News list don't scrool while click on column "read/unread" if cursor is out of view</li>
+<li>Fixed: News list don't scroll while click on column "read/unread" if cursor is out of view</li>
 <li>Fixed: Request url queues while update feeds</li>
 <li>Fixed: Parsing "alternate" url of the news of Atom-feeds</li>
 <li>Fixed: TrayMenu is not appear sometimes</li>
@@ -965,7 +965,7 @@
 
 <p><b>Version 0.8.0</b> (31 Jan 2012)
 <ul>
-<li>Added: Sumiltaneous update up to 8 feeds</li>
+<li>Added: Simultaneous update up to 8 feeds</li>
 </ul>
 
 <p><b>Version 0.7.6</b> (28 Jan 2012)

--- a/lang/quiterss_ru.qph
+++ b/lang/quiterss_ru.qph
@@ -6,7 +6,7 @@
 </phrase>
 <phrase>
     <source>Next</source>
-    <target>Следущий файл</target>
+    <target>Следующий файл</target>
 </phrase>
 <phrase>
     <source>Open</source>
@@ -154,7 +154,7 @@
 </phrase>
 <phrase>
     <source>Proxy enabled</source>
-    <target>Прокси включен</target>
+    <target>Прокси включён</target>
 </phrase>
 <phrase>
     <source>Select OPML-file</source>
@@ -558,7 +558,7 @@
 </phrase>
 <phrase>
     <source>Move to the system tray when:</source>
-    <target>Помещать в сиcтемный трей:</target>
+    <target>Помещать в системный трей:</target>
 </phrase>
 <phrase>
     <source>No load images</source>
@@ -1599,7 +1599,7 @@
 </phrase>
 <phrase>
     <source>Deleted</source>
-    <target>Удаленные</target>
+    <target>Удалённые</target>
 </phrase>
 <phrase>
     <source>Starred</source>
@@ -1719,7 +1719,7 @@
 </phrase>
 <phrase>
     <source>Restore last deleted news</source>
-    <target>Восстановление последней удалёной новости</target>
+    <target>Восстановление последней удалённой новости</target>
 </phrase>
 <phrase>
     <source>Next Unread News</source>
@@ -1939,7 +1939,7 @@
 </phrase>
 <phrase>
     <source>Simplified representation of date and time</source>
-    <target>Упрощенное представление даты и времени</target>
+    <target>Упрощённое представление даты и времени</target>
 </phrase>
 <phrase>
     <source>Change behavior of action &apos;Next Unread News&apos;</source>
@@ -2051,7 +2051,7 @@
 </phrase>
 <phrase>
     <source>Do you want to also delete downloaded file?</source>
-    <target>Вы хотите удалить скачаный файл?</target>
+    <target>Вы хотите удалить скачанный файл?</target>
 </phrase>
 <phrase>
     <source>Open File</source>
@@ -2223,7 +2223,7 @@
 </phrase>
 <phrase>
     <source>starred news</source>
-    <target>новостей отмеченых звёздочкой</target>
+    <target>новостей отмеченных звёздочкой</target>
 </phrase>
 <phrase>
     <source>Expand Folder</source>
@@ -2354,7 +2354,7 @@
 <phrase>
     <source>Totally remove records that had marked &apos;deleted&apos; from DB.
 Ancient news could reappear</source>
-    <target>Полностью удаляет записи, которые отмечены как &quot;удаленные&quot; из БД.
+    <target>Полностью удаляет записи, которые отмечены как &quot;удалённые&quot; из БД.
 Возможно, удалённые новости загрузятся снова</target>
 </phrase>
 <phrase>
@@ -2391,7 +2391,7 @@ Ancient news could reappear</source>
 </phrase>
 <phrase>
     <source>Cookies:</source>
-    <target>Файлы сookies:</target>
+    <target>Файлы cookies:</target>
 </phrase>
 <phrase>
     <source>Count of news unread in feeds tree</source>
@@ -2701,7 +2701,7 @@ Save?</source>
 </phrase>
 <phrase>
     <source>Cannot load subscription!</source>
-    <target>Не удается загрузить подписку!</target>
+    <target>Не удаётся загрузить подписку!</target>
 </phrase>
 <phrase>
     <source>%1 (Error: %2)</source>
@@ -2709,7 +2709,7 @@ Save?</source>
 </phrase>
 <phrase>
     <source>Cannot load subscription!</source>
-    <target>Не удается загрузить подписку!</target>
+    <target>Не удаётся загрузить подписку!</target>
 </phrase>
 <phrase>
     <source>Add Custom Rule</source>

--- a/lang/quiterss_ru.ts
+++ b/lang/quiterss_ru.ts
@@ -242,7 +242,7 @@
     <message>
         <location filename="../src/adblock/adblocksubscription.cpp" line="195"/>
         <source>Cannot load subscription!</source>
-        <translation>Не удается загрузить подписку!</translation>
+        <translation>Не удаётся загрузить подписку!</translation>
     </message>
 </context>
 <context>
@@ -440,7 +440,7 @@
     <message>
         <location filename="../src/categoriestreewidget.cpp" line="67"/>
         <source>Deleted</source>
-        <translation>Удаленные</translation>
+        <translation>Удалённые</translation>
     </message>
     <message>
         <location filename="../src/categoriestreewidget.cpp" line="72"/>
@@ -529,7 +529,7 @@
         <location filename="../src/cleanupwizard.cpp" line="361"/>
         <source>Totally remove records that had marked 'deleted' from DB.
 Ancient news could reappear</source>
-        <translation>Полностью удаляет записи, которые отмечены как &quot;удаленные&quot; из БД.
+        <translation>Полностью удаляет записи, которые отмечены как &quot;удалённые&quot; из БД.
 Возможно, удалённые новости загрузятся снова</translation>
     </message>
     <message>
@@ -1844,7 +1844,7 @@ Ancient news could reappear</source>
     <message>
         <location filename="../src/application/mainwindow.cpp" line="4925"/>
         <source>Restore last deleted news</source>
-        <translation>Восстановление последней удалёной новости</translation>
+        <translation>Восстановление последней удалённой новости</translation>
     </message>
     <message>
         <location filename="../src/application/mainwindow.cpp" line="4927"/>
@@ -2357,7 +2357,7 @@ Ancient news could reappear</source>
     <message>
         <location filename="../src/application/mainwindow.cpp" line="5057"/>
         <source>Deleted</source>
-        <translation>Удаленные</translation>
+        <translation>Удалённые</translation>
     </message>
     <message>
         <location filename="../src/application/mainwindow.cpp" line="5058"/>
@@ -3101,7 +3101,7 @@ Ancient news could reappear</source>
     <message>
         <location filename="../src/optionsdialog.cpp" line="391"/>
         <source>Move to the system tray when:</source>
-        <translation>Помещать в сиcтемный трей:</translation>
+        <translation>Помещать в системный трей:</translation>
     </message>
     <message>
         <location filename="../src/optionsdialog.cpp" line="394"/>
@@ -3292,7 +3292,7 @@ Ancient news could reappear</source>
     <message>
         <location filename="../src/optionsdialog.cpp" line="655"/>
         <source>Cookies:</source>
-        <translation>Файлы сookies:</translation>
+        <translation>Файлы cookies:</translation>
     </message>
     <message>
         <location filename="../src/optionsdialog.cpp" line="664"/>
@@ -3394,7 +3394,7 @@ Ancient news could reappear</source>
     <message>
         <location filename="../src/optionsdialog.cpp" line="844"/>
         <source>Simplified representation of date and time</source>
-        <translation>Упрощенное представление даты и времени</translation>
+        <translation>Упрощённое представление даты и времени</translation>
     </message>
     <message>
         <location filename="../src/optionsdialog.cpp" line="847"/>


### PR DESCRIPTION
Various spelling corrections. Russian "с" in "cookies", latin "c" in "сиcтемный", missing "ё", etc.