### PR TITLE
Fix Qt 5 compilation warning

### DIFF
--- a/src/common/delegatewithoutfocus.cpp
+++ b/src/common/delegatewithoutfocus.cpp
@@ -26,7 +26,11 @@ void DelegateWithoutFocus::paint(QPainter *painter,
                                  const QStyleOptionViewItem &option,
                                  const QModelIndex &index) const
 {
+#if QT_VERSION >= 0x050000
+  QStyleOptionViewItem opt = option;
+#else  
   QStyleOptionViewItemV4 opt = option;
+#endif
   opt.state &= ~QStyle::State_HasFocus;
   QStyledItemDelegate::paint(painter,opt,index);
 }


### PR DESCRIPTION
```
../src/common/delegatewithoutfocus.cpp: In member function ‘virtual void DelegateWithoutFocus::paint(QPainter*, const QStyleOptionViewItem&, const QModelIndex&) const’:
../src/common/delegatewithoutfocus.cpp:29:26: warning: ‘QStyleOptionViewItemV4’ is deprecated [-Wdeprecated-declarations]
   QStyleOptionViewItemV4 opt = option;
                          ^~~
In file included from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qabstractitemdelegate.h:45:0,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/qstyleditemdelegate.h:44,
                 from /usr/include/x86_64-linux-gnu/qt5/QtWidgets/QStyledItemDelegate:1,
                 from ../src/common/delegatewithoutfocus.h:21,
                 from ../src/common/delegatewithoutfocus.cpp:18:
/usr/include/x86_64-linux-gnu/qt5/QtWidgets/qstyleoption.h:453:48: note: declared here
 typedef Q_DECL_DEPRECATED QStyleOptionViewItem QStyleOptionViewItemV4;
```