### PR TITLE
Fixed GCC 7 compilation warnings

### DIFF
--- a/3rdparty/qftp/qftp.cpp
+++ b/3rdparty/qftp/qftp.cpp
@@ -1174,7 +1174,7 @@ bool QFtpPI::processReply()
         break;
     case Success:
         // success handling
-        state = Idle;
+        state = Idle; // fall through
         // no break!
     case Idle:
         if (dtp.hasError()) {

--- a/src/webview/webpage.cpp
+++ b/src/webview/webpage.cpp
@@ -173,7 +173,7 @@ void WebPage::handleUnsupportedContent(QNetworkReply* reply)
       }
       mainApp->downloadManager()->handleUnsupportedContent(reply, mainApp->mainWindow()->askDownloadLocation_);
       return;
-    }
+    } // fall through
 
   case QNetworkReply::ProtocolUnknownError: {
     qDebug() << "WebPage::UnsupportedContent" << url << "ProtocolUnknowError";


### PR DESCRIPTION
```
../3rdparty/qftp/qftp.cpp: In member function ‘bool QFtpPI::processReply()’:
../3rdparty/qftp/qftp.cpp:1177:15: warning: this statement may fall through [-Wimplicit-fallthrough=]
         state = Idle;
         ~~~~~~^~~~~~
../3rdparty/qftp/qftp.cpp:1179:5: note: here
     case Idle:
     ^~~~
```
```
../src/webview/webpage.cpp: In member function ‘void WebPage::handleUnsupportedContent(QNetworkReply*)’:
../src/webview/webpage.cpp:176:5: warning: this statement may fall through [-Wimplicit-fallthrough=]
     }
     ^
../src/webview/webpage.cpp:178:3: note: here
   case QNetworkReply::ProtocolUnknownError: {
   ^~~~
```