### PR TITLE
Add a Calendar to avoid downloading old news

### DIFF
--- a/src/application/mainwindow.h
+++ b/src/application/mainwindow.h
@@ -227,6 +227,8 @@ public:
   bool notDeleteStarred_;
   bool notDeleteLabeled_;
   bool markIdenticalNewsRead_;
+  bool avoidOldNews_;
+  QDate avoidedOldNewsDate_;
 
   bool autoLoadImages_;
   bool openLinkInBackground_;

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -36,6 +36,7 @@ private:
   static void createTables(QSqlDatabase &db);
   static void prepareDatabase();
   static void createLabels(QSqlDatabase &db);
+  static void addColumnsToFeedsTables(QSqlDatabase &db);
 
   static QStringList tablesList() {
     QStringList tables;

--- a/src/feedpropertiesdialog.cpp
+++ b/src/feedpropertiesdialog.cpp
@@ -129,6 +129,25 @@ QWidget *FeedPropertiesDialog::createGeneralTab()
   layoutGeneralGrid->addWidget(labelURLCapt, 1, 0);
   layoutGeneralGrid->addWidget(editURL, 1, 1);
 
+  addSingleNewsAnyDateOn_ = new QCheckBox(tr("Add news with any date into the database"));
+  addSingleNewsAnyDateOn_->setFixedWidth(450);
+  addSingleNewsAnyDateOn_->setCheckable(true);
+  addSingleNewsAnyDateOn_->setChecked(false);
+
+  avoidedOldSingleNewsDate_ = new QCalendarWidget();
+  avoidedOldSingleNewsDate_->setFixedWidth(400);
+  avoidedOldSingleNewsDate_->setSelectedDate(QDate::currentDate());
+  avoidedOldSingleNewsDate_->setVerticalHeaderFormat(QCalendarWidget::NoVerticalHeader);
+  avoidedOldSingleNewsDate_->setHorizontalHeaderFormat(QCalendarWidget::SingleLetterDayNames);
+  QHBoxLayout *avoidedOldNewsDateLayout = new QHBoxLayout();
+  avoidedOldNewsDateLayout->addWidget(avoidedOldSingleNewsDate_);
+
+  avoidedOldSingleNewsDateOn_ = new QGroupBox(tr("Avoid adding news before this date into the database:"));
+  avoidedOldSingleNewsDateOn_->setFixedWidth(450);
+  avoidedOldSingleNewsDateOn_->setCheckable(true);
+  avoidedOldSingleNewsDateOn_->setChecked(false);
+  avoidedOldSingleNewsDateOn_->setLayout(avoidedOldNewsDateLayout);
+
   QVBoxLayout *tabLayout = new QVBoxLayout(tab);
   tabLayout->setMargin(10);
   tabLayout->setSpacing(5);
@@ -142,6 +161,18 @@ QWidget *FeedPropertiesDialog::createGeneralTab()
   tabLayout->addWidget(displayOnStartup);
   tabLayout->addWidget(duplicateNewsMode_);
   tabLayout->addStretch();
+  tabLayout->addSpacing(15);
+  tabLayout->addWidget(addSingleNewsAnyDateOn_);
+  tabLayout->addStretch();
+  tabLayout->addWidget(avoidedOldSingleNewsDateOn_);
+  tabLayout->addStretch();
+
+  connect(addSingleNewsAnyDateOn_, SIGNAL(toggled(bool)),
+          this, SLOT(setGroupBoxCheckboxState(bool)));
+  connect(addSingleNewsAnyDateOn_, SIGNAL(toggled(bool)),
+          avoidedOldSingleNewsDateOn_, SLOT(setDisabled(bool)));
+  connect(addSingleNewsAnyDateOn_, SIGNAL(toggled(bool)),
+          tabLayout, SLOT(setDisabled(bool)));
 
   connect(loadTitleButton, SIGNAL(clicked()), this, SLOT(setDefaultTitle()));
   connect(selectIconButton_, SIGNAL(clicked()),
@@ -160,6 +191,9 @@ QWidget *FeedPropertiesDialog::createGeneralTab()
     labelHomepage->hide();
     starredOn_->hide();
     duplicateNewsMode_->hide();
+    addSingleNewsAnyDateOn_->hide();
+    avoidedOldSingleNewsDateOn_->hide();
+    avoidedOldSingleNewsDate_->hide();
   }
 
   return tab;
@@ -376,6 +410,10 @@ QWidget *FeedPropertiesDialog::createStatusTab()
   starredOn_->setChecked(feedProperties.general.starred);
   duplicateNewsMode_->setChecked(feedProperties.general.duplicateNewsMode);
 
+  addSingleNewsAnyDateOn_->setChecked(feedProperties.general.addSingleNewsAnyDateOn);
+  avoidedOldSingleNewsDateOn_->setChecked(feedProperties.general.avoidedOldSingleNewsDateOn);
+  avoidedOldSingleNewsDate_->setSelectedDate(feedProperties.general.avoidedOldSingleNewsDate);
+
   loadImagesOn_->setCheckState((Qt::CheckState)feedProperties.display.displayEmbeddedImages);
   javaScriptEnable_->setCheckState((Qt::CheckState)feedProperties.display.javaScriptEnable);
   showDescriptionNews_->setChecked(!feedProperties.display.displayNews);
@@ -517,6 +555,13 @@ FEED_PROPERTIES FeedPropertiesDialog::getFeedProperties()
   feedProperties.display.displayNews = !showDescriptionNews_->isChecked();
   feedProperties.general.duplicateNewsMode = duplicateNewsMode_->isChecked();
   feedProperties.display.layoutDirection = layoutDirection_->isChecked();
+  feedProperties.general.addSingleNewsAnyDateOn = addSingleNewsAnyDateOn_->isChecked();
+  feedProperties.general.avoidedOldSingleNewsDateOn = avoidedOldSingleNewsDateOn_->isChecked();
+  if (!avoidedOldSingleNewsDate_->selectedDate().isNull() && avoidedOldSingleNewsDate_->selectedDate().isValid()) {
+    feedProperties.general.avoidedOldSingleNewsDate = avoidedOldSingleNewsDate_->selectedDate();
+  } else {
+    feedProperties.general.avoidedOldSingleNewsDate = QDate::currentDate();
+  }
 
   feedProperties.column.columns.clear();
   for (int i = 0; i < columnsTree_->topLevelItemCount(); ++i) {
@@ -639,4 +684,13 @@ void FeedPropertiesDialog::defaultColumns()
       sortByColumnBox_->setCurrentIndex(i);
   }
   sortOrderBox_->setCurrentIndex(feedProperties.columnDefault.sortType);
+}
+//------------------------------------------------------------------------------
+void FeedPropertiesDialog::setGroupBoxCheckboxState(bool _on)
+{
+  if (_on) {
+    avoidedOldSingleNewsDateOn_->setChecked(false);
+  } else {
+    avoidedOldSingleNewsDateOn_->setChecked(true);
+  }
 }

--- a/src/feedpropertiesdialog.h
+++ b/src/feedpropertiesdialog.h
@@ -39,6 +39,9 @@ typedef struct {
     int displayOnStartup; //!< Flag to display feed on startup in sepatare tab
     bool starred; //!< Starred feed (favourite)
     bool duplicateNewsMode; //!< Automatically delete news duplicates
+    bool avoidedOldSingleNewsDateOn; //!< Avoid adding news before this date into the database
+    bool addSingleNewsAnyDateOn; //!< Add news with any date into the database
+    QDate avoidedOldSingleNewsDate; //!< Date to avoid
   } general;
 
   //! Autthentication properties
@@ -144,6 +147,7 @@ private slots:
   void moveUpColumn();
   void moveDownColumn();
   void defaultColumns();
+  void setGroupBoxCheckboxState(bool _on);
 
 private:
   QTabWidget *tabWidget;
@@ -160,6 +164,9 @@ private:
   QCheckBox *displayOnStartup;
   QCheckBox *starredOn_;
   QCheckBox *duplicateNewsMode_;
+  QCheckBox *addSingleNewsAnyDateOn_;
+  QGroupBox *avoidedOldSingleNewsDateOn_;
+  QCalendarWidget *avoidedOldSingleNewsDate_;
 
   QWidget *createGeneralTab();
 

--- a/src/optionsdialog.cpp
+++ b/src/optionsdialog.cpp
@@ -795,6 +795,24 @@ void OptionsDialog::createFeedsWidget()
 
   markIdenticalNewsRead_ = new QCheckBox(tr("Automatically mark identical news as read"));
 
+  QFrame *hLine = new QFrame();
+  hLine->setFrameStyle(QFrame::HLine | QFrame::Sunken);
+
+  avoidedOldNewsDate_ = new QCalendarWidget();
+  avoidedOldNewsDate_->setFixedWidth(400);
+  avoidedOldNewsDate_->setSelectedDate(QDate::currentDate());
+  avoidedOldNewsDate_->setVerticalHeaderFormat(QCalendarWidget::NoVerticalHeader);
+  avoidedOldNewsDate_->setHorizontalHeaderFormat(QCalendarWidget::SingleLetterDayNames);
+  QHBoxLayout *avoidedOldNewsDateLayout = new QHBoxLayout();
+  avoidedOldNewsDateLayout->addWidget(avoidedOldNewsDate_);
+
+  avoidedOldNewsDateOn_ = new QGroupBox(tr("Avoid adding news before this date into the database:"));
+  avoidedOldNewsDateOn_->setFixedWidth(500);
+  avoidedOldNewsDateOn_->setStyleSheet("QGroupBox {padding-top: 25}");
+  avoidedOldNewsDateOn_->setCheckable(true);
+  avoidedOldNewsDateOn_->setChecked(false);
+  avoidedOldNewsDateOn_->setLayout(avoidedOldNewsDateLayout);
+
   QVBoxLayout *generalFeedsLayout = new QVBoxLayout();
   generalFeedsLayout->addWidget(updateFeedsStartUp_);
   generalFeedsLayout->addLayout(updateFeedsLayout);
@@ -802,6 +820,10 @@ void OptionsDialog::createFeedsWidget()
   generalFeedsLayout->addWidget(new QLabel(tr("Action on feed opening:")));
   generalFeedsLayout->addLayout(openingFeedsLayout);
   generalFeedsLayout->addWidget(markIdenticalNewsRead_);
+  generalFeedsLayout->addSpacing(15);
+  generalFeedsLayout->addWidget(hLine);
+  generalFeedsLayout->addSpacing(7);
+  generalFeedsLayout->addWidget(avoidedOldNewsDateOn_);
   generalFeedsLayout->addStretch();
 
   QWidget *generalFeedsWidget = new QWidget();

--- a/src/optionsdialog.h
+++ b/src/optionsdialog.h
@@ -156,6 +156,9 @@ public:
   QCheckBox *cleanUpDeleted_;
   QCheckBox *optimizeDB_;
 
+  QGroupBox *avoidedOldNewsDateOn_;
+  QCalendarWidget *avoidedOldNewsDate_;
+
   // labels
   QStringList idLabels_;
   QTreeWidget *labelsTree_;
@@ -281,6 +284,7 @@ private:
   QWidget *languageWidget_;
   QTabWidget *fontsColorsWidget_;
   QWidget *shortcutWidget_;
+  QWidget *avoidOldNewsWidget_;
 
   // general
   void createGeneralWidget();

--- a/src/parseobject.cpp
+++ b/src/parseobject.cpp
@@ -474,7 +474,7 @@ void ParseObject::addAtomNewsIntoBase(NewsItemStruct *newsItem)
    }
 
   // if duplicates not found and is old news, add them into base
-  if (isDuplicate == false and isOld == false) {
+  if (!isDuplicate && !isOld) {
     bool read = false;
     if (mainApp->mainWindow()->markIdenticalNewsRead_) {
       q.prepare("SELECT id FROM news WHERE title LIKE :title AND feedId!=:id");
@@ -754,7 +754,7 @@ void ParseObject::addRssNewsIntoBase(NewsItemStruct *newsItem)
    }
 
  // if duplicates not found And old news, add them into base
- if (isDuplicate == false and isOld == false) {
+ if (!isDuplicate && !isOld) {
     bool read = false;
     if (mainApp->mainWindow()->markIdenticalNewsRead_) {
       q.prepare("SELECT id FROM news WHERE title LIKE :title AND feedId!=:id");

--- a/src/parseobject.cpp
+++ b/src/parseobject.cpp
@@ -109,16 +109,23 @@ void ParseObject::slotParse(const QByteArray &xmlData, const int &feedId,
 
   db_.transaction();
 
-  // extract feed id and duplicate news mode from feed table
+  // extract feed id, duplicate news mode and date to avoid from feed table
   parseFeedId_ = feedId;
   QString feedUrl;
   duplicateNewsMode_ = false;
+  addSingleNewsAnyDate_ = false;
+  avoidedOldSingleNews_ = false;
+  avoidedOldSingleNewsDate_ = QDate::currentDate();
   QSqlQuery q(db_);
   q.setForwardOnly(true);
-  q.exec(QString("SELECT duplicateNewsMode, xmlUrl FROM feeds WHERE id=='%1'").arg(parseFeedId_));
+  q.exec(QString("SELECT duplicateNewsMode, xmlUrl, addSingleNewsAnyDateOn, avoidedOldSingleNewsDateOn, avoidedOldSingleNewsDate"
+                 " FROM feeds WHERE id=='%1'").arg(parseFeedId_));
   if (q.first()) {
     duplicateNewsMode_ = q.value(0).toBool();
     feedUrl = q.value(1).toString();
+    addSingleNewsAnyDate_ = q.value(2).toBool();
+    avoidedOldSingleNews_ = q.value(3).toBool();
+    avoidedOldSingleNewsDate_ = q.value(4).toDate();
   }
 
   // id not found (ex. feed deleted while updating)
@@ -453,8 +460,21 @@ void ParseObject::addAtomNewsIntoBase(NewsItemStruct *newsItem)
     if (isDuplicate) break;
   }
 
-  // if duplicates not found, add news into base
-  if (!isDuplicate) {
+  // Verify old news before a date to avoid adding them to base
+  bool isOld = false;
+  QDateTime pubDate_ = QDateTime::fromString(newsItem->updated, "yyyy-MM-ddTHH:mm:ss");
+  QDateTime avoidedDate_ = QDateTime(mainApp->mainWindow()->avoidedOldNewsDate_);
+  if (!addSingleNewsAnyDate_) {      //
+    if (avoidedOldSingleNews_ ) {     // avoid adding old single news
+      if (QDateTime(avoidedOldSingleNewsDate_) > pubDate_)
+        isOld = true;
+      } else if (mainApp->mainWindow()->avoidOldNews_ && avoidedDate_ > pubDate_) {   // avoid adding old news
+        isOld = true;
+      }
+   }
+
+  // if duplicates not found and is old news, add them into base
+  if (isDuplicate == false and isOld == false) {
     bool read = false;
     if (mainApp->mainWindow()->markIdenticalNewsRead_) {
       q.prepare("SELECT id FROM news WHERE title LIKE :title AND feedId!=:id");
@@ -720,8 +740,21 @@ void ParseObject::addRssNewsIntoBase(NewsItemStruct *newsItem)
     if (isDuplicate) break;
   }
 
-  // if duplicates not found, add news into base
-  if (!isDuplicate) {
+  // Verify old news before a date to avoid adding them to base
+  bool isOld = false;
+  QDateTime pubDate_ = QDateTime::fromString(newsItem->updated, "yyyy-MM-ddTHH:mm:ss");
+  QDateTime avoidedDate_ = QDateTime(mainApp->mainWindow()->avoidedOldNewsDate_);
+  if (!addSingleNewsAnyDate_) {      //
+    if (avoidedOldSingleNews_ ) {     // avoid adding old single news
+      if (QDateTime(avoidedOldSingleNewsDate_) > pubDate_)
+        isOld = true;
+      } else if (mainApp->mainWindow()->avoidOldNews_ && avoidedDate_ > pubDate_) {   // avoid adding old news
+              isOld = true;
+      }
+   }
+
+ // if duplicates not found And old news, add them into base
+ if (isDuplicate == false and isOld == false) {
     bool read = false;
     if (mainApp->mainWindow()->markIdenticalNewsRead_) {
       q.prepare("SELECT id FROM news WHERE title LIKE :title AND feedId!=:id");

--- a/src/parseobject.h
+++ b/src/parseobject.h
@@ -118,6 +118,9 @@ private:
   int parseFeedId_;
   bool duplicateNewsMode_;
   bool feedChanged_;
+  bool addSingleNewsAnyDate_;
+  bool avoidedOldSingleNews_;
+  QDate avoidedOldSingleNewsDate_;
 
   QStringList guidList_;
   QStringList linkList_;


### PR DESCRIPTION
This Calendar let us to avoid downloading old news to preserve a small database.

I Added 2 options:
- Set a general date for all feeds (in Option -> Feeds -> General).
- Set a date for a desired single feed (in Feeds -> Properties -> General).

If we purge the database, we can ensure that the news having a date old than the chosen date (as above)
will not be downloaded.
The same with a new empty database.