### PR TITLE
Fix AppStream metadata validation

### DIFF
--- a/quiterss.appdata.xml
+++ b/quiterss.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright (C) 2011-2015 QuiteRSS Team <quiterssteam@gmail.com> -->
-<application>
-  <id type="desktop">quiterss.desktop</id>
+<component type="desktop-application">
+  <id>org.quiterss.quiterss</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>QuiteRSS</name>
@@ -15,10 +15,17 @@
     </p>
   </description>
   <screenshots>
-  <screenshot type="default" width="790" height="538">https://github.com/QuiteRSS/tools/raw/master/screenshots/screenshots01.png</screenshot>
-  <screenshot width="790" height="538">https://github.com/QuiteRSS/tools/raw/master/screenshots/screenshots02.png</screenshot>
-  <screenshot width="683" height="595">https://github.com/QuiteRSS/tools/raw/master/screenshots/screenshots07.png</screenshot>
+  <screenshot type="default">
+    <image width="790" height="538">https://github.com/QuiteRSS/tools/raw/master/screenshots/screenshots01.png</image>
+  </screenshot>
+  <screenshot>
+    <image width="790" height="538">https://github.com/QuiteRSS/tools/raw/master/screenshots/screenshots02.png</image>
+  </screenshot>
+  <screenshot>
+    <image width="683" height="595">https://github.com/QuiteRSS/tools/raw/master/screenshots/screenshots07.png</image>
+  </screenshot>
   </screenshots>
+  <launchable type="desktop-id">quiterss.desktop</launchable>
   <url type="homepage">https://quiterss.org</url>
-  <updatecontact>quiterssteam@gmail.com</updatecontact>
-</application>
+  <update_contact>quiterssteam@gmail.com</update_contact>
+</component>


### PR DESCRIPTION
This updates the AppStream metadata to a newer version, and fixes all compatibility problems detected by `appstreamcli validate quiterss.appdata.xml`:
```
E - quiterss.appdata.xml:quiterss.desktop:19
    The screenshot does not contain any images.

E - quiterss.appdata.xml:quiterss.desktop:18
    The screenshot does not contain any images.

E - quiterss.appdata.xml:quiterss.desktop:20
    The screenshot does not contain any images.

I - quiterss.appdata.xml:quiterss.desktop:4
    The id tag for "quiterss.desktop" still contains a 'type' property, probably 
    from an old conversion.

W - quiterss.appdata.xml:quiterss.desktop:4
    The component ID is not a reverse domain-name. Please update the ID and that of 
    the accompanying .desktop file to follow the latest version of the Desktop-Entry 
    and AppStream specifications and avoid future issues.

W - quiterss.appdata.xml:quiterss.desktop:23
    Found invalid tag: 'updatecontact'. Non-standard tags must be prefixed with 
    "x-".
```