### PR TITLE
Add and fixed selection color in dark.qss.

### DIFF
--- a/style/dark.qss
+++ b/style/dark.qss
@@ -4,8 +4,8 @@ QWidget {
     background-color: #464546; /* dark */
     alternate-background-color: #3a393a; /* veryDark */
     color: #e1e0e1; /* veryLight */
-    selection-background-color: #2a82da;
-    selection-color: white;
+    selection-background-color: #3A393B;
+    selection-color: #F8FD99;
 }
 QWidget:disabled {
 	color: gray;
@@ -33,7 +33,13 @@ QMenuBar::item:selected {
 
 #feedsView_::item, #newsView_::item, #newsCategoriesTree_::item {
 	min-height: 20px;
+	color: #e1e0e1;
 }
+#feedsView_::item:selected, #newsView_::item:selected, #newsCategoriesTree_::item:selected {
+	background-color: #3A393B;
+	color: #F8FD99;
+}
+
 
 #categoriesLabel_, #newsTextTitle_ {
 	color: #e1e0e1;
@@ -239,7 +245,7 @@ QLineEdit {
 
 QLineEdit:focus {
 	border: 1 solid #2a82da;
-	color: white;
+	color: #e1e0e1;
 }
 
 #click2flash-frame {
@@ -276,7 +282,7 @@ QPushButton {
 
 QPushButton:focus {
 	border: 1 solid #2a82da;
-	color: white;
+	color: #e1e0e1;
 }
 
 QScrollBar:vertical {
@@ -321,7 +327,7 @@ QComboBox {
 }
 
 QComboBox:on { 
-	color: white;
+	color: #e1e0e1;
 }
 
 QComboBox::drop-down {
@@ -350,5 +356,5 @@ QSpinBox {
 
 QSpinBox:focus {
 	border: 1 solid #2a82da;
-	color: white;
+	color: #e1e0e1;
 }


### PR DESCRIPTION
1. [Fixed selection color in #877](https://github.com/QuiteRSS/quiterss/issues/877#issuecomment-555196332).
2. Selection (On-focus) color to shining (Light yellow).
3. White (`#FFFFFF`) has high contrast, too bright. thus Align with `#e1e0e1b` of other places.
![quiterssfix1](https://user-images.githubusercontent.com/41102508/69896084-82d49b80-137e-11ea-85f8-7b6ceb53e8c3.png)
![quiterssoriginal](https://user-images.githubusercontent.com/41102508/69896085-849e5f00-137e-11ea-96e8-8fd892316a48.png)

