### PR TITLE
Add and fixed selection color in dark.qss.

### DIFF
--- a/style/dark.qss
+++ b/style/dark.qss
@@ -4,8 +4,8 @@ QWidget {
     background-color: #464546; /* dark */
     alternate-background-color: #3a393a; /* veryDark */
     color: #e1e0e1; /* veryLight */
-    selection-background-color: #2a82da;
-    selection-color: white;
+    selection-background-color: #3A393B;
+    selection-color: #F8FD99;
 }
 QWidget:disabled {
 	color: gray;
@@ -34,6 +34,11 @@ QMenuBar::item:selected {
 #feedsView_::item, #newsView_::item, #newsCategoriesTree_::item {
 	min-height: 20px;
 }
+#feedsView_::item:selected, #newsView_::item:selected, #newsCategoriesTree_::item:selected {
+	background-color: #3A393B;
+	color: #F8FD99;
+}
+
 
 #categoriesLabel_, #newsTextTitle_ {
 	color: #e1e0e1;
@@ -239,7 +244,7 @@ QLineEdit {
 
 QLineEdit:focus {
 	border: 1 solid #2a82da;
-	color: white;
+	color: #e1e0e1;
 }
 
 #click2flash-frame {
@@ -276,7 +281,7 @@ QPushButton {
 
 QPushButton:focus {
 	border: 1 solid #2a82da;
-	color: white;
+	color: #e1e0e1;
 }
 
 QScrollBar:vertical {
@@ -321,7 +326,7 @@ QComboBox {
 }
 
 QComboBox:on { 
-	color: white;
+	color: #e1e0e1;
 }
 
 QComboBox::drop-down {
@@ -350,5 +355,5 @@ QSpinBox {
 
 QSpinBox:focus {
 	border: 1 solid #2a82da;
-	color: white;
+	color: #e1e0e1;
 }


### PR DESCRIPTION
1. [Fixed selection color in #877](https://github.com/QuiteRSS/quiterss/issues/877#issuecomment-555196332).
2. Selection (On-focus) color to shining (Light yellow).
3. White (`#FFFFFF`) has high contrast, too bright. thus Align with `#e1e0e1b` of other places.
![quiterssfix1](https://user-images.githubusercontent.com/41102508/69896304-48b8c900-1381-11ea-85fc-9780dd7cdccf.png)
![quiterssoriginal](https://user-images.githubusercontent.com/41102508/69896306-4a828c80-1381-11ea-881e-9aaac4ea3ff2.png)
