### PR TITLE
Extract globals from MainApplication

### DIFF
--- a/QuiteRSS.pro
+++ b/QuiteRSS.pro
@@ -118,6 +118,7 @@ HEADERS += \
     src/network/networkmanagerproxy.h \
     src/adblock/adblockmatcher.h \
     src/feedsview/feedsproxymodel.h \
+    src/main/globals.h \
 
 SOURCES += \
     src/parseobject.cpp \
@@ -154,6 +155,7 @@ SOURCES += \
     src/application/settings.cpp \
     src/application/logfile.cpp \
     src/application/mainwindow.cpp \
+    src/main/globals.cpp \
     src/main/main.cpp \
     src/adblock/adblocktreewidget.cpp \
     src/adblock/adblocksubscription.cpp \

--- a/src/application/logfile.cpp
+++ b/src/application/logfile.cpp
@@ -38,37 +38,14 @@ void LogFile::msgHandler(QtMsgType type, const QMessageLogContext &, const QStri
     return;
 
   if (type == QtDebugMsg) {
-    Settings settings; // FIXME: possible race with Settings::createSettings()?
+    Settings settings;
     settings.beginGroup("Settings");
     if (settings.value("noDebugOutput", true).toBool())
       return;
   }
 
-  bool isPortable = false;
-#if defined(Q_OS_WIN)
-  isPortable = true;
-  QString fileName(QCoreApplication::applicationDirPath() + "/portable.dat");
-  if (!QFile::exists(fileName)) {
-    isPortable = false;
-  }
-#endif
-  QString dataDir;
-
-  if (isPortable) {
-    dataDir = QCoreApplication::applicationDirPath();
-  } else {
-#ifdef HAVE_QT5
-    dataDir = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
-#else
-    dataDir = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
-#endif
-
-    QDir dir(dataDir);
-    dir.mkpath(dataDir);
-  }
-
   QFile file;
-  file.setFileName(dataDir + "/debug.log");
+  file.setFileName(globals.dataDir + "/debug.log");
   QIODevice::OpenMode openMode = QIODevice::WriteOnly | QIODevice::Text;
 
   if (file.exists() && (file.size() < (qint64)maxLogFileSize)) {
@@ -112,37 +89,14 @@ void LogFile::msgHandler(QtMsgType type, const char *msg)
     return;
 
   if (type == QtDebugMsg) {
-    Settings settings; // FIXME: possible race with Settings::createSettings()?
+    Settings settings;
     settings.beginGroup("Settings");
     if (settings.value("noDebugOutput", true).toBool())
       return;
   }
 
-  bool isPortable = false;
-#if defined(Q_OS_WIN)
-  isPortable = true;
-  QString fileName(QCoreApplication::applicationDirPath() + "/portable.dat");
-  if (!QFile::exists(fileName)) {
-    isPortable = false;
-  }
-#endif
-  QString dataDir;
-
-  if (isPortable) {
-    dataDir = QCoreApplication::applicationDirPath();
-  } else {
-#ifdef HAVE_QT5
-    dataDir = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
-#else
-    dataDir = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
-#endif
-
-    QDir dir(dataDir);
-    dir.mkpath(dataDir);
-  }
-
   QFile file;
-  file.setFileName(dataDir + "/debug.log");
+  file.setFileName(globals.dataDir + "/debug.log");
   QIODevice::OpenMode openMode = QIODevice::WriteOnly | QIODevice::Text;
 
   if (file.exists() && (file.size() < (qint64)maxLogFileSize)) {

--- a/src/application/logfile.cpp
+++ b/src/application/logfile.cpp
@@ -24,6 +24,7 @@
 #endif
 #include <QDir>
 
+#include "globals.h"
 #include "settings.h"
 
 LogFile::LogFile()

--- a/src/application/mainapplication.cpp
+++ b/src/application/mainapplication.cpp
@@ -20,6 +20,7 @@
 #include "common.h"
 #include "cookiejar.h"
 #include "database.h"
+#include "globals.h"
 #include "networkmanager.h"
 #include "adblockmanager.h"
 #include "settings.h"
@@ -183,33 +184,23 @@ void MainApplication::checkDir()
 #endif
 #endif
 
-  if (isPortable_) {
-    dataDir_ = QCoreApplication::applicationDirPath();
+  dataDir_ = globals.dataDir;
+  if (globals.isPortable) {
     cacheDir_ = "cache";
     soundNotifyDir_ = "sound";
   } else {
 #ifdef HAVE_QT5
-    dataDir_ = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
     cacheDir_ = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
 #else
-    dataDir_ = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
     cacheDir_ = QDesktopServices::storageLocation(QDesktopServices::CacheLocation);
 #endif
     soundNotifyDir_ = resourcesDir_ % "/sound";
-
-    QDir dir(dataDir_);
-    dir.mkpath(dataDir_);
   }
   dataDirInitialized_ = true;
 }
 
 void MainApplication::createSettings()
 {
-  QString fileName;
-  if (isPortable_)
-    fileName = mainApp->dataDir() % "/" % QCoreApplication::applicationName() % ".ini";
-  Settings::createSettings(fileName);
-
   Settings settings;
   settings.beginGroup("Settings");
   storeDBMemory_ = settings.value("storeDBMemory", true).toBool();
@@ -336,7 +327,7 @@ void MainApplication::commitData(QSessionManager &manager)
 
 bool MainApplication::isPortable() const
 {
-  return isPortable_;
+  return globals.isPortable;
 }
 
 bool MainApplication::isPortableAppsCom() const
@@ -367,7 +358,7 @@ QString MainApplication::dataDir() const
 QString MainApplication::absolutePath(const QString &path) const
 {
   QString absolutePath = path;
-  if (isPortable_) {
+  if (globals.isPortable) {
     if (!QDir::isAbsolutePath(path)) {
       absolutePath = dataDir_ % "/" % path;
     }
@@ -532,7 +523,7 @@ QString MainApplication::soundNotifyDefaultFile() const
 
 QString MainApplication::styleSheetNewsDefaultFile() const
 {
-  if (isPortable_) {
+  if (globals.isPortable) {
     return "style/news.css";
   } else {
     return resourcesDir_ % "/style/news.css";
@@ -541,7 +532,7 @@ QString MainApplication::styleSheetNewsDefaultFile() const
 
 QString MainApplication::styleSheetWebDarkFile() const
 {
-  if (isPortable_) {
+  if (globals.isPortable) {
     return "style/web_dark.css";
   } else {
     return resourcesDir_ % "/style/web_dark.css";

--- a/src/application/mainapplication.cpp
+++ b/src/application/mainapplication.cpp
@@ -30,10 +30,8 @@
 
 MainApplication::MainApplication(int &argc, char **argv)
   : QtSingleApplication(argc, argv)
-  , isPortable_(false)
   , isPortableAppsCom_(false)
   , isClosing_(false)
-  , dataDirInitialized_(false)
   , dbFileExists_(false)
   , translator_(0)
   , mainWindow_(0)
@@ -67,8 +65,6 @@ MainApplication::MainApplication(int &argc, char **argv)
   setWindowIcon(QIcon(":/images/quiterss128"));
   setQuitOnLastWindowClosed(false);
   QSettings::setDefaultFormat(QSettings::IniFormat);
-
-  checkPortable();
 
   checkDir();
 
@@ -154,24 +150,6 @@ void MainApplication::receiveMessage(const QString &message)
   }
 }
 
-void MainApplication::checkPortable()
-{
-#if defined(Q_OS_WIN)
-  isPortable_ = true;
-  QString fileName(QCoreApplication::applicationDirPath() + "/portable.dat");
-  if (!QFile::exists(fileName)) {
-    isPortable_ = false;
-  }
-  if (isPortable_) {
-    fileName = QCoreApplication::applicationDirPath() + "/../../QuiteRSSPortable.exe";
-    if (QFile::exists(fileName)) {
-      isPortableAppsCom_ = true;
-      QFile::remove(QCoreApplication::applicationDirPath() + "/Updater.exe");
-    }
-  }
-#endif
-}
-
 void MainApplication::checkDir()
 {
 #if defined(Q_OS_WIN) || defined(Q_OS_OS2)
@@ -196,7 +174,6 @@ void MainApplication::checkDir()
 #endif
     soundNotifyDir_ = resourcesDir_ % "/sound";
   }
-  dataDirInitialized_ = true;
 }
 
 void MainApplication::createSettings()

--- a/src/application/mainapplication.h
+++ b/src/application/mainapplication.h
@@ -52,7 +52,6 @@ public:
   bool isClosing() const;
   bool isNoDebugOutput() const { return noDebugOutput_; }
   void showClosingWidget();
-  bool dataDirInitialized() const { return dataDirInitialized_; }
 
   QString resourcesDir() const;
   QString dataDir() const;
@@ -103,7 +102,6 @@ private slots:
   void commitData(QSessionManager &manager);
 
 private:
-  void checkPortable();
   void checkDir();
   void createSettings();
   void createGoogleAnalytics();
@@ -116,10 +114,8 @@ private:
 
   QUrl userStyleSheet(const QString &filePath) const;
 
-  bool isPortable_;
   bool isPortableAppsCom_;
   bool isClosing_;
-  bool dataDirInitialized_;
 
   QString resourcesDir_;
   QString dataDir_;

--- a/src/application/settings.cpp
+++ b/src/application/settings.cpp
@@ -19,26 +19,26 @@
 
 #include <QCoreApplication>
 
-QSettings *Settings::settings_ = 0;
+#include "globals.h"
 
 Settings::Settings()
 {
-  if (!settings_->group().isEmpty())
-    settings_->endGroup();
+  if (!globals.settings->group().isEmpty())
+    globals.settings->endGroup();
 }
 
 Settings::~Settings()
 {
-  if (!settings_->group().isEmpty())
-    settings_->endGroup();
+  if (!globals.settings->group().isEmpty())
+    globals.settings->endGroup();
 }
 
 void Settings::createSettings(const QString &fileName)
 {
   if (!fileName.isEmpty()) {
-    settings_ = new QSettings(fileName, QSettings::IniFormat);
+    globals.settings = new QSettings(fileName, QSettings::IniFormat);
   } else {
-    settings_ = new QSettings(QSettings::IniFormat,
+    globals.settings = new QSettings(QSettings::IniFormat,
                               QSettings::UserScope,
                               QCoreApplication::organizationName(),
                               QCoreApplication::applicationName());
@@ -47,40 +47,40 @@ void Settings::createSettings(const QString &fileName)
 
 QSettings* Settings::getSettings()
 {
-    return settings_;
+    return globals.settings;
 }
 
 void Settings::syncSettings()
 {
-  settings_->sync();
+  globals.settings->sync();
 }
 
 QString Settings::fileName()
 {
-  return settings_->fileName();
+  return globals.settings->fileName();
 }
 
 void Settings::beginGroup(const QString &prefix)
 {
-  settings_->beginGroup(prefix);
+  globals.settings->beginGroup(prefix);
 }
 
 void Settings::endGroup()
 {
-  settings_->endGroup();
+  globals.settings->endGroup();
 }
 
 void Settings::setValue(const QString &key, const QVariant &defaultValue)
 {
-  settings_->setValue(key, defaultValue);
+  globals.settings->setValue(key, defaultValue);
 }
 
 QVariant Settings::value(const QString &key, const QVariant &defaultValue)
 {
-  return settings_->value(key, defaultValue);
+  return globals.settings->value(key, defaultValue);
 }
 
 bool Settings::contains(const QString &key)
 {
-  return settings_->contains(key);
+  return globals.settings->contains(key);
 }

--- a/src/application/settings.h
+++ b/src/application/settings.h
@@ -38,10 +38,6 @@ public:
   void setValue(const QString &key, const QVariant &defaultValue = QVariant());
   QVariant value(const QString &key, const QVariant &defaultValue = QVariant());
   bool contains(const QString &key);
-
-private:
-  static QSettings* settings_;
-
 };
 
 #endif // SETTINGS_H

--- a/src/main/globals.cpp
+++ b/src/main/globals.cpp
@@ -1,0 +1,67 @@
+/* ============================================================
+* QuiteRSS is a open-source cross-platform RSS/Atom news feeds reader
+* Copyright (C) 2011-2019 QuiteRSS Team <quiterssteam@gmail.com>
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* ============================================================ */
+#include "globals.h"
+
+#ifdef HAVE_QT5
+#include <QStandardPaths>
+#else
+#include <QDesktopServices>
+#endif
+#include <QCoreApplication>
+#include <QDir>
+#include <QStringBuilder>
+
+#include "settings.h"
+
+Globals globals;
+
+Globals::Globals()
+  : logFileOutput(false)
+  , isPortable(false)
+  , dataDir()
+  , settings(NULL)
+{
+  // isPortable ...
+#if defined(Q_OS_WIN)
+  isPortable = true;
+  QString fileName(QCoreApplication::applicationDirPath() + "/portable.dat");
+  if (!QFile::exists(fileName)) {
+    isPortable = false;
+  }
+#endif
+
+  // dataDir ...
+  if (isPortable) {
+    dataDir = QCoreApplication::applicationDirPath();
+  } else {
+#ifdef HAVE_QT5
+    dataDir = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+#else
+    dataDir = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
+#endif
+
+    QDir dir(dataDir);
+    dir.mkpath(dataDir);
+  }
+
+  // settings ...
+  QString settingsFileName;
+  if (isPortable)
+    settingsFileName = dataDir % "/" % QCoreApplication::applicationName() % ".ini";
+  Settings::createSettings(settingsFileName);
+}

--- a/src/main/globals.h
+++ b/src/main/globals.h
@@ -1,0 +1,38 @@
+/* ============================================================
+* QuiteRSS is a open-source cross-platform RSS/Atom news feeds reader
+* Copyright (C) 2011-2019 QuiteRSS Team <quiterssteam@gmail.com>
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <https://www.gnu.org/licenses/>.
+* ============================================================ */
+#ifndef GLOBALS_H
+#define GLOBALS_H
+
+#include <QSettings>
+#include <QString>
+
+class Globals
+{
+public:
+  Globals();
+
+  // public on purpose
+  const bool logFileOutput;
+  bool isPortable;
+  QString dataDir;
+  QSettings *settings;
+};
+
+extern Globals globals;
+
+#endif // GLOBALS_H

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -15,14 +15,14 @@
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 * ============================================================ */
+#include "globals.h"
 #include "mainapplication.h"
 #include "logfile.h"
-
-const bool logFileOutput = 1;
+#include "settings.h"
 
 int main(int argc, char **argv)
 {
-  if (logFileOutput) {
+  if (globals.logFileOutput) {
 #if defined(HAVE_QT5)
     qInstallMessageHandler(LogFile::msgHandler);
 #else


### PR DESCRIPTION
This is a more thorough/elaborate attempt at fixing #1198 

This builds on #1229.
- create a class holding a few relevant fields
- move initialization code for its fields there
- create a global static instance of it
- use new globals where appropriate in `LogFile`, `MainApplication`, `Settings`

I must say my C++ is a bit rusty, but maybe this helps you come up with a better idea. :grinning: 