### PR TITLE
Fix App name in dirs

### DIFF
--- a/src/application/mainapplication.cpp
+++ b/src/application/mainapplication.cpp
@@ -41,6 +41,9 @@ MainApplication::MainApplication(int &argc, char **argv)
   , downloadManager_(0)
   , analytics_(0)
 {
+  setApplicationName("QuiteRss");
+  setOrganizationName("QuiteRss");
+  setApplicationVersion(STRPRODUCTVER);
   globals.init();
 
   QString message = arguments().value(1);
@@ -61,9 +64,6 @@ MainApplication::MainApplication(int &argc, char **argv)
     }
   }
 
-  setApplicationName("QuiteRss");
-  setOrganizationName("QuiteRss");
-  setApplicationVersion(STRPRODUCTVER);
   setWindowIcon(QIcon(":/images/quiterss128"));
   setQuitOnLastWindowClosed(false);
   QSettings::setDefaultFormat(QSettings::IniFormat);

--- a/src/main/globals.cpp
+++ b/src/main/globals.cpp
@@ -71,7 +71,7 @@ void Globals::init()
     soundNotifyDir_ = "sound";
   } else {
 #ifdef HAVE_QT5
-    dataDir_ = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+    dataDir_ = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
     cacheDir_ = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
 #else
     dataDir_ = QDesktopServices::storageLocation(QDesktopServices::DataLocation);


### PR DESCRIPTION
Fixes last issue with #1230 and following changes by @Funcy-dcm .

Set applicationName and organizationName before globals.init() ... otherwise the application name will be derived from the executable name (i.e. "quiterss") and used in data and cache paths. This leads QuiteRSS to look for config and cache files in the wrong directories.

Example data directory:
wrong: "\~/.local/share/quiterss"
fixed: "\~/.local/share/QuiteRss/QuiteRss"
