### PR TITLE
Added system qt5 translation preload

### DIFF
--- a/src/application/mainapplication.cpp
+++ b/src/application/mainapplication.cpp
@@ -34,6 +34,7 @@ MainApplication::MainApplication(int &argc, char **argv)
   , isClosing_(false)
   , dbFileExists_(false)
   , translator_(0)
+  , qt_translator_(0)
   , mainWindow_(0)
   , networkManager_(0)
   , cookieJar_(0)
@@ -373,6 +374,11 @@ void MainApplication::setTranslateApplication()
   removeTranslator(translator_);
   translator_->load(resourcesDir() + QString("/lang/quiterss_%1").arg(langFileName_));
   installTranslator(translator_);
+  if (!qt_translator_)
+    qt_translator_ = new QTranslator(this);
+  qt_translator_ = new QTranslator(this);
+  qt_translator_->load(QLibraryInfo::location (QLibraryInfo::TranslationsPath) + "/qtbase_" + QLocale::system().name());
+  installTranslator(qt_translator_);
 }
 
 void MainApplication::showSplashScreen()

--- a/src/application/mainapplication.h
+++ b/src/application/mainapplication.h
@@ -27,6 +27,8 @@
 #endif
 #include <qtsingleapplication.h>
 #include <QNetworkDiskCache>
+#include <QLocale>
+#include <QLibraryInfo>
 
 #include "cookiejar.h"
 #include "downloadmanager.h"
@@ -124,6 +126,7 @@ private:
   bool updateFeedsStartUp_;
 
   QTranslator *translator_;
+  QTranslator *qt_translator_;
   QString langFileName_;
   SplashScreen *splashScreen_;
   MainWindow *mainWindow_;


### PR DESCRIPTION
It is necessary to load the qt5 system translations in order for the system dialogs to be translated. For example, the print dialog.