### PR TITLE
Using HTML tags to play audio and video instead of flash

### DIFF
--- a/html/audioplayer.html
+++ b/html/audioplayer.html
@@ -1,1 +1,4 @@
-<object type="application/x-shockwave-flash" data="http://flv-mp3.com/i/pic/ump3player_500x70.swf" height="52" width="350"><param name="wmode" value="transparent" /><param name="allowFullScreen" value="true" /><param name="allowScriptAccess" value="always" /><param name="movie" value="http://flv-mp3.com/i/pic/ump3player_500x70.swf" /><param name="FlashVars" value="way=%1&amp;swf=http://flv-mp3.com/i/pic/ump3player_500x70.swf&amp;w=350&amp;h=52&amp;time_seconds=0&amp;autoplay=0&amp;q=1&amp;skin=black&amp;volume=70&amp;comment=" /></object>
+<audio controls>
+  <source src="%1" type="audio/ogg">
+Your browser does not support the audio element.
+</audio>

--- a/html/videoplayer.html
+++ b/html/videoplayer.html
@@ -1,1 +1,4 @@
-<object type="application/x-shockwave-flash" data="http://flv-mp3.com/i/pic/uflvplayer_500x375.swf" height="300" width="400"><param name="bgcolor" value="#FFFFFF" /><param name="allowFullScreen" value="true" /><param name="allowScriptAccess" value="always" /><param name="movie" value="http://flv-mp3.com/i/pic/uflvplayer_500x375.swf" /><param name="FlashVars" value="way=%1&amp;swf=http://flv-mp3.com/i/pic/uflvplayer_500x375.swf&amp;w=400&amp;h=300&amp;pic=http://&amp;autoplay=0&amp;tools=2&amp;skin=black&amp;volume=70&amp;q=1&amp;comment=" /></object>
+<video width="400" height="300" controls>
+  <source src="%1">
+Your browser does not support the video tag.
+</video>


### PR DESCRIPTION
Hi,
I am using Mac and found that the flash mp3 player does not work for some sites, such as https://www.podcastfrancaisfacile.com/feed.

So I fixed this by using html5 tags, it is supported by WebKit/web engine already. Also it is better for security and compatibilities in the future while fash is abandoned everywhere.