### PR TITLE
add "View All YouTube Videos (Experimental)" context-menu action to Unread category

### DIFF
--- a/QuiteRSS.pro
+++ b/QuiteRSS.pro
@@ -64,6 +64,7 @@ HEADERS += \
     src/feedpropertiesdialog.h \
     src/addfeedwizard.h \
     src/newstabwidget.h \
+    src/youtubeserver.h \
     src/findtext.h \
     src/findfeed.h \
     src/feedsview/feedsview.h \
@@ -134,6 +135,7 @@ SOURCES += \
     src/feedpropertiesdialog.cpp \
     src/addfeedwizard.cpp \
     src/newstabwidget.cpp \
+    src/youtubeserver.cpp \
     src/findtext.cpp \
     src/findfeed.cpp \
     src/feedsview/feedsview.cpp \

--- a/QuiteRSS.qrc
+++ b/QuiteRSS.qrc
@@ -120,6 +120,7 @@
         <file alias="newspaper_description">html/newspaper_description.html</file>
         <file alias="newspaper_head">html/newspaper_head.html</file>
         <file alias="newspaper_description_rtl">html/newspaper_description_rtl.html</file>
+        <file alias="sequential_youtube_player">html/sequential_youtube_player.html</file>
     </qresource>
     <qresource prefix="/flags">
         <file alias="flag_AR">images/flags/flag_arab.png</file>

--- a/html/sequential_youtube_player.html
+++ b/html/sequential_youtube_player.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>YouTube Sequential Player</title>
+    <style>
+        body {
+            background-color: black;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            flex-direction: column;
+            height: auto;
+            margin: 0;
+            color: white;
+            text-align: center;
+            overflow: auto;
+        }
+        #player-container {
+            margin-bottom: 20px;
+        }
+        #current-title {
+            font-size: 20px;
+            margin-bottom: 10px;
+            color: white;
+        }
+        #queue {
+            list-style-type: none;
+            padding: 0;
+            margin: 0;
+            width: auto;
+        }
+        #queue li {
+            background-color: #333;
+            padding: 10px;
+            margin-bottom: 5px;
+            cursor: pointer;
+            color: white;
+            border-radius: 5px;
+            text-align: left;
+            user-select: none;
+            display: flex;
+            align-items: center;
+            position: relative;
+        }
+        #queue li.current {
+            background-color: #f0f0f0;
+            color: black;
+            font-weight: bold;
+        }
+        #controls {
+            margin-top: 20px;
+        }
+        a {
+            color: white;
+            margin: 0 15px;
+            cursor: pointer;
+            text-decoration: none;
+            padding: 8px 12px;
+            border: 2px solid white;
+            border-radius: 5px;
+            transition: background-color 0.3s;
+        }
+        a:hover {
+            background-color: white;
+            color: black;
+        }
+        a.disabled {
+            color: grey;
+            cursor: not-allowed;
+            border-color: grey;
+        }
+    </style>
+    <script>
+        var tag = document.createElement('script');
+        tag.src = "https://www.youtube.com/iframe_api";
+        var firstScriptTag = document.getElementsByTagName('script')[0];
+        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+        var videos = [%1];
+
+        var currentIndex = 0;
+        var player;
+
+        function onYouTubeIframeAPIReady() {
+            player = new YT.Player('player', {
+                height: '390',
+                width: '640',
+                videoId: videos[currentIndex].id,
+                playerVars: {
+                    'autoplay': 1,
+                    'controls': 1,
+                    'rel': 0,
+                    'modestbranding': 1
+                },
+                events: {
+                    'onReady': onPlayerReady,
+                    'onStateChange': onPlayerStateChange
+                }
+            });
+
+            updateQueueUI();
+        }
+
+        function onPlayerReady() {
+            updateControls();
+            refocusPlayer();
+        }
+
+        function onPlayerStateChange(event) {
+            if (event.data === YT.PlayerState.ENDED) {
+                loadNextVideo();
+            }
+        }
+
+        function loadVideoAtIndex(index) {
+            currentIndex = index;
+            player.loadVideoById(videos[currentIndex].id);
+            updateControls();
+            refocusPlayer();
+            updateQueueUI();
+        }
+
+        function loadPreviousVideo() {
+            if (currentIndex > 0) {
+                currentIndex--;
+                player.loadVideoById(videos[currentIndex].id);
+                updateControls();
+                refocusPlayer();
+                updateQueueUI();
+            }
+        }
+
+        function loadNextVideo() {
+            if (currentIndex < videos.length - 1) {
+                currentIndex++;
+                player.loadVideoById(videos[currentIndex].id);
+                updateControls();
+                refocusPlayer();
+                updateQueueUI();
+            }
+        }
+
+        function refocusPlayer() {
+            var iframe = document.getElementById('player');
+            if (iframe) {
+                iframe.focus();
+            }
+        }
+
+        function updateControls() {
+            var prevLink = document.getElementById('prev');
+            var nextLink = document.getElementById('next');
+
+            prevLink.classList.toggle('disabled', currentIndex === 0);
+            nextLink.classList.toggle('disabled', currentIndex === videos.length - 1);
+        }
+
+        function updateQueueUI() {
+            var queue = document.getElementById('queue');
+            var currentTitle = document.getElementById('current-title');
+            queue.innerHTML = '';
+            currentTitle.textContent = videos[currentIndex].title;
+
+            videos.forEach((video, index) => {
+                var listItem = document.createElement('li');
+                listItem.textContent = `${index + 1}. ${video.title}`;
+                listItem.dataset.index = index;
+
+                if (index === currentIndex) {
+                    listItem.classList.add('current');
+                }
+
+                listItem.addEventListener('click', function() {
+                    loadVideoAtIndex(index);
+                });
+
+                queue.appendChild(listItem);
+            });
+        }
+
+        document.addEventListener('keydown', function (event) {
+            const theKey = event.key.toLowerCase();
+            switch (theKey) {
+                case 'm': // Mute/unmute the video
+                    const isMuted = player.isMuted();
+                    if (isMuted) {
+                        player.unMute();
+                    } else {
+                        player.mute();
+                    }
+                    break;
+                case 'f': // Enter/exit fullscreen
+                    if (!document.fullscreenElement) {
+                        const iframe = player.getIframe();
+                        if (iframe) {
+                            iframe.requestFullscreen();
+                        }
+                    } else {
+                        document.exitFullscreen();
+                    }
+                    break;
+                case 'n': // Play next video
+                case 'enter':
+                    loadNextVideo();
+                    break;
+                case 'p': // Play previous video
+                    loadPreviousVideo();
+                    break;
+                case ' ': // Play/pause the video
+                    event.preventDefault();
+                    const playerState = player.getPlayerState();
+                    if (playerState === YT.PlayerState.PAUSED || playerState === YT.PlayerState.ENDED) {
+                        player.playVideo();
+                    } else if (playerState === YT.PlayerState.PLAYING) {
+                        player.pauseVideo();
+                    }
+                    break;
+                case 'arrowright': // Skip forward 5 seconds
+                    const currentTimeForward = player.getCurrentTime();
+                    player.seekTo(currentTimeForward + 5, true);
+                    break;
+                case 'arrowleft': // Skip backward 5 seconds
+                    const currentTimeBackward = player.getCurrentTime();
+                    player.seekTo(Math.max(0, currentTimeBackward - 5), true);
+                    break;
+            }
+        });
+    </script>
+</head>
+<body>
+    <div id="player-container">
+        <div id="current-title"></div>
+        <div id="player"></div>
+        <div id="controls">
+            <a id="prev" class="disabled" onclick="loadPreviousVideo()">Previous</a>
+            <a id="next" onclick="loadNextVideo()">Next</a>
+        </div>
+    </div>
+
+    <ul id="queue"></ul>
+</body>
+</html>

--- a/html/sequential_youtube_player.html
+++ b/html/sequential_youtube_player.html
@@ -240,5 +240,12 @@
     </div>
 
     <ul id="queue"></ul>
+
+    <script>
+      // SSE connection to keep server alive
+      const evtSource = new EventSource('/sse');
+      evtSource.onopen = function() { console.log('SSE connected'); };
+      evtSource.onerror = function(err) { console.log('SSE error:', err); };
+    </script>
 </body>
 </html>

--- a/src/application/mainwindow.cpp
+++ b/src/application/mainwindow.cpp
@@ -549,6 +549,8 @@ void MainWindow::createFeedsWidget()
           this, SLOT(clearDeleted()));
   connect(categoriesTree_, SIGNAL(signalMarkRead(QTreeWidgetItem*)),
           this, SLOT(slotMarkReadCategory(QTreeWidgetItem*)));
+  connect(categoriesTree_, SIGNAL(signalViewAllYoutubeVideos()),
+          this, SLOT(viewAllYoutubeVideos()));
   connect(showCategoriesButton_, SIGNAL(clicked()),
           this, SLOT(showNewsCategoriesTree()));
   connect(feedsSplitter_, SIGNAL(splitterMoved(int,int)),
@@ -7583,6 +7585,11 @@ void MainWindow::slotMarkReadCategory(QTreeWidgetItem *item)
     emit signalMarkReadCategory(type, labelId);
     recountCategoryCounts();
   }
+}
+
+void MainWindow::viewAllYoutubeVideos()
+{
+  currentNewsTab->viewAllYoutubeVideos();
 }
 
 /** @brief Show/Hide categories tree

--- a/src/application/mainwindow.h
+++ b/src/application/mainwindow.h
@@ -455,6 +455,7 @@ private slots:
   void slotCategoriesClicked(QTreeWidgetItem *item, int, bool createTab = false);
   void clearDeleted();
   void slotMarkReadCategory(QTreeWidgetItem *item);
+  void viewAllYoutubeVideos();
   void showNewsCategoriesTree();
   void feedsSplitterMoved(int pos, int);
 

--- a/src/categoriestreewidget.cpp
+++ b/src/categoriestreewidget.cpp
@@ -142,6 +142,10 @@ void CategoriesTreeWidget::showContextMenuCategory(const QPoint &pos)
         menu.addSeparator();
         menu.addAction(tr("Mark Read"), this, SLOT(slotMarkRead()));
       }
+      if (itemClicked_ == topLevelItem(UnreadItem)) {
+        menu.addSeparator();
+        menu.addAction(tr("View All Youtube Videos (Experimental)"), this, SIGNAL(signalViewAllYoutubeVideos()));
+      }
       menu.exec(viewport()->mapToGlobal(pos));
     }
   }

--- a/src/categoriestreewidget.h
+++ b/src/categoriestreewidget.h
@@ -57,6 +57,7 @@ signals:
   void signalMiddleClicked();
   void signalClearDeleted();
   void signalMarkRead(QTreeWidgetItem *item);
+  void signalViewAllYoutubeVideos();
 //  void pressKeyUp();
 //  void pressKeyDown();
 

--- a/src/newstabwidget.cpp
+++ b/src/newstabwidget.cpp
@@ -21,6 +21,7 @@
 #include "adblockicon.h"
 #include "settings.h"
 #include "webpage.h"
+#include "youtubeserver.h"
 
 #if defined(Q_OS_WIN)
 #include <qt_windows.h>
@@ -34,6 +35,7 @@ NewsTabWidget::NewsTabWidget(QWidget *parent, TabType type, int feedId, int feed
   , feedParId_(feedParId)
   , currentNewsIdOld(-1)
   , autoLoadImages_(true)
+  , youtubeServer_(nullptr)
 {
   mainWindow_ = mainApp->mainWindow();
   db_ = QSqlDatabase::database();
@@ -143,6 +145,11 @@ NewsTabWidget::NewsTabWidget(QWidget *parent, TabType type, int feedId, int feed
 
 NewsTabWidget::~NewsTabWidget()
 {
+  if (youtubeServer_) {
+    youtubeServer_->stop();
+    delete youtubeServer_;
+    youtubeServer_ = nullptr;
+  }
   if (type_ == TabTypeDownloads) {
     mainApp->downloadManager()->hide();
     mainApp->downloadManager()->setParent(mainWindow_);
@@ -1062,6 +1069,22 @@ void NewsTabWidget::viewAllYoutubeVideos()
       }
   }
   if (allYoutubeVideos.isEmpty()) return;
+
+  // Stop existing server if running
+  if (youtubeServer_) {
+    youtubeServer_->stop();
+    delete youtubeServer_;
+    youtubeServer_ = nullptr;
+  }
+
+  // Create and start ephemeral HTTP server
+  youtubeServer_ = new YoutubeServer(this);
+  if (!youtubeServer_->start(0)) { // 0 = auto-select port
+    delete youtubeServer_;
+    youtubeServer_ = nullptr;
+    return;
+  }
+
   QFile sequentialYoutubePlayerHtmlFile;
   sequentialYoutubePlayerHtmlFile.setFileName(":/html/sequential_youtube_player");
   sequentialYoutubePlayerHtmlFile.open(QFile::ReadOnly);
@@ -1084,15 +1107,10 @@ void NewsTabWidget::viewAllYoutubeVideos()
 
   sequentialYoutubePlayerHtml = sequentialYoutubePlayerHtml.arg(videoTitlesAndIdsJavascript);
 
-  QTemporaryFile tempFile(QDir::tempPath() + "/sequential-youtube-player-XXXXXX.html");
-  if (tempFile.open()) {
-      tempFile.setAutoRemove(false);
-      QTextStream tempFileStream(&tempFile);
-      tempFileStream << sequentialYoutubePlayerHtml;
-      tempFile.close();
-      QUrl tempFileUrl = "file://" + tempFile.fileName();
-      openUrl(tempFileUrl);
-  }
+  youtubeServer_->setHtmlContent(sequentialYoutubePlayerHtml);
+
+  // Open the HTTP server URL in browser
+  openUrl(QUrl(youtubeServer_->serverUrl()));
 }
 
 /** @brief Mark selected news Starred

--- a/src/newstabwidget.h
+++ b/src/newstabwidget.h
@@ -77,6 +77,7 @@ public:
   void setBrowserPosition();
   void markNewsRead();
   void markAllNewsRead();
+  void viewAllYoutubeVideos();
   void markNewsStar();
   void setLabelNews(int labelId);
   void deleteNews();

--- a/src/newstabwidget.h
+++ b/src/newstabwidget.h
@@ -38,6 +38,7 @@
 #include "webview.h"
 
 class MainWindow;
+class YoutubeServer;
 
 #define TOP_POSITION    0
 #define BOTTOM_POSITION 1
@@ -235,6 +236,7 @@ private:
   QString audioPlayerHtml_;
   QString videoPlayerHtml_;
 
+  class YoutubeServer *youtubeServer_;
 };
 
 #endif // NEWSTABWIDGET_H

--- a/src/youtubeserver.cpp
+++ b/src/youtubeserver.cpp
@@ -1,0 +1,207 @@
+/*************************************************************
+ * QuiteRSS - Youtube Ephemeral HTTP Server
+ * Serves sequential_youtube_player.html with SSE client tracking
+ *************************************************************/
+
+#include "youtubeserver.h"
+#include <QTcpSocket>
+#include <QTcpServer>
+#include <QTimer>
+#include <QDateTime>
+
+YoutubeServer::YoutubeServer(QObject *parent)
+    : QObject(parent)
+    , server_(nullptr)
+    , port_(0)
+{
+    idleTimer_ = new QTimer(this);
+    connect(idleTimer_, SIGNAL(timeout()), this, SLOT(checkIdleTimeout()));
+}
+
+YoutubeServer::~YoutubeServer()
+{
+    stop();
+}
+
+bool YoutubeServer::start(quint16 port)
+{
+    if (server_)
+        return true;
+
+    server_ = new QTcpServer(this);
+    connect(server_, SIGNAL(newConnection()), this, SLOT(handleNewConnection()));
+
+    if (!server_->listen(QHostAddress::LocalHost, port)) {
+        delete server_;
+        server_ = nullptr;
+        return false;
+    }
+
+    port_ = server_->serverPort();
+    idleTimer_->start(60000); // Check every minute
+
+    return true;
+}
+
+void YoutubeServer::stop()
+{
+    idleTimer_->stop();
+
+    // Close all client connections
+    QHashIterator<QTcpSocket*, QDateTime> it(clients_);
+    while (it.hasNext()) {
+        it.next();
+        QTcpSocket *socket = it.key();
+        socket->close();
+        socket->deleteLater();
+    }
+    clients_.clear();
+    sseClients_.clear();
+
+    if (server_) {
+        server_->close();
+        delete server_;
+        server_ = nullptr;
+    }
+
+    port_ = 0;
+}
+
+bool YoutubeServer::isRunning() const
+{
+    return server_ && server_->isListening();
+}
+
+QString YoutubeServer::serverUrl() const
+{
+    if (!isRunning())
+        return QString();
+    return QString("http://127.0.0.1:%1").arg(port_);
+}
+
+void YoutubeServer::setHtmlContent(const QString &html)
+{
+    htmlContent_ = html;
+}
+
+void YoutubeServer::handleNewConnection()
+{
+    while (server_->hasPendingConnections()) {
+        QTcpSocket *socket = server_->nextPendingConnection();
+        connect(socket, SIGNAL(disconnected()), this, SLOT(handleClientDisconnected()));
+        connect(socket, SIGNAL(readyRead()), this, SLOT(handleClientReadyRead()));
+        clients_.insert(socket, QDateTime::currentDateTime());
+    }
+}
+
+void YoutubeServer::handleClientDisconnected()
+{
+    QTcpSocket *socket = qobject_cast<QTcpSocket*>(sender());
+    if (!socket)
+        return;
+
+    clients_.remove(socket);
+    sseClients_.remove(socket);
+    socket->deleteLater();
+}
+
+void YoutubeServer::handleClientReadyRead()
+{
+    QTcpSocket *socket = qobject_cast<QTcpSocket*>(sender());
+    if (!socket || !clients_.contains(socket))
+        return;
+
+    // Update last activity time
+    clients_.insert(socket, QDateTime::currentDateTime());
+
+    // Read HTTP request
+    QByteArray request = socket->readAll();
+    QString requestStr = QString::fromUtf8(request);
+
+    // Check if this is an SSE request
+    if (requestStr.contains("Accept: text/event-stream") ||
+        requestStr.contains("accept: text/event-stream")) {
+        // SSE endpoint
+        sseClients_.insert(socket, true);
+        sendSseHeaders(socket);
+        return;
+    }
+
+    // Serve the HTML page
+    if (requestStr.startsWith("GET") || requestStr.contains("GET /")) {
+        QByteArray htmlBytes = htmlContent_.toUtf8();
+        sendHttpResponse(socket, 200, "text/html; charset=utf-8", htmlBytes);
+        return;
+    }
+
+    // Default: 404
+    sendHttpResponse(socket, 404, "text/plain", QByteArray("Not Found"));
+}
+
+void YoutubeServer::checkIdleTimeout()
+{
+    QDateTime now = QDateTime::currentDateTime();
+
+    // Check for idle clients
+    QMutableHashIterator<QTcpSocket*, QDateTime> it(clients_);
+    while (it.hasNext()) {
+        it.next();
+        QTcpSocket *socket = it.key();
+        QDateTime lastActivity = it.value();
+
+        if (lastActivity.msecsTo(now) > IDLE_TIMEOUT_MS) {
+            // Close idle connection
+            socket->close();
+            // Note: socket will be cleaned up in handleClientDisconnected
+        }
+    }
+
+    // Send keepalive to SSE clients
+    QHashIterator<QTcpSocket*, bool> sseIt(sseClients_);
+    while (sseIt.hasNext()) {
+        sseIt.next();
+        QTcpSocket *socket = sseIt.key();
+        if (socket->state() == QAbstractSocket::ConnectedState) {
+            // Send SSE comment (keepalive)
+            socket->write(":keepalive\n\n");
+            socket->flush();
+        }
+    }
+
+    // If no clients at all and running, we could auto-stop here
+    // But the requirement says to stay alive until QuiteRSS closes or idle timeout
+    // So we keep running
+}
+
+void YoutubeServer::sendHttpResponse(QTcpSocket *socket, int statusCode, const QString &contentType, const QByteArray &body)
+{
+    QString statusText = (statusCode == 200) ? "OK" : "Not Found";
+    QByteArray response = QString("HTTP/1.1 %1 %2\r\n"
+                                  "Content-Type: %3\r\n"
+                                  "Content-Length: %4\r\n"
+                                  "Connection: close\r\n"
+                                  "\r\n")
+                               .arg(statusCode)
+                               .arg(statusText)
+                               .arg(contentType)
+                               .arg(body.size())
+                               .toUtf8();
+    response.append(body);
+
+    socket->write(response);
+    socket->flush();
+    socket->waitForBytesWritten(5000);
+    socket->close();
+}
+
+void YoutubeServer::sendSseHeaders(QTcpSocket *socket)
+{
+    QByteArray headers = "HTTP/1.1 200 OK\r\n"
+                         "Content-Type: text/event-stream\r\n"
+                         "Cache-Control: no-cache\r\n"
+                         "Connection: keep-alive\r\n"
+                         "\r\n";
+    socket->write(headers);
+    socket->flush();
+    // Don't close - keep connection open for SSE
+}

--- a/src/youtubeserver.h
+++ b/src/youtubeserver.h
@@ -1,0 +1,49 @@
+/* ============================================================
+ * QuiteRSS - Youtube Ephemeral HTTP Server
+ * Serves sequential_youtube_player.html with SSE client tracking
+ * ============================================================ */
+#ifndef YOUTUBESERVER_H
+#define YOUTUBESERVER_H
+
+#include <QObject>
+#include <QTcpServer>
+#include <QTcpSocket>
+#include <QTimer>
+#include <QHash>
+#include <QDateTime>
+
+class YoutubeServer : public QObject
+{
+    Q_OBJECT
+public:
+    explicit YoutubeServer(QObject *parent = nullptr);
+    ~YoutubeServer();
+
+    bool start(quint16 port = 0); // port 0 = auto-select
+    void stop();
+    bool isRunning() const;
+    QString serverUrl() const;
+    void setHtmlContent(const QString &html);
+
+private slots:
+    void handleNewConnection();
+    void handleClientDisconnected();
+    void handleClientReadyRead();
+    void checkIdleTimeout();
+
+private:
+    void sendHttpResponse(QTcpSocket *socket, int statusCode, const QString &contentType, const QByteArray &body);
+    void sendSseHeaders(QTcpSocket *socket);
+    void closeClientConnection(QTcpSocket *socket);
+
+    QTcpServer *server_;
+    QString htmlContent_;
+    QHash<QTcpSocket*, QDateTime> clients_; // socket -> last activity time
+    QHash<QTcpSocket*, bool> sseClients_;   // socket -> is SSE client
+    QTimer *idleTimer_;
+    quint16 port_;
+    static const int IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+    static const int SSE_KEEPALIVE_INTERVAL_MS = 30000; // 30 seconds
+};
+
+#endif // YOUTUBESERVER_H


### PR DESCRIPTION
1) Make sure you have some YouTube channels as feeds (and some of them Unread) 
2) Left-click on the "Unread" category (in bottom-left) to select it, as right-clicking doesn't select it for some reason (bug #1610)
3) Now Right click on Unread and choose "View All YouTube Videos (Experimental)" and it will open up a custom/local html file that plays all of the videos back to back

I know this is sort of ugly that's why I tucked it away neatly in that context menu and put "Experimental" next to it. I see tons of room for improvement but please don't ask me to add feature X or Polish Y as I don't have a lot of time to work on this. It works good enough for me. Just accept the PR as-is and file additional PRs with your own upgrades, but I'm allowing edits by maintainers for necessary changes.